### PR TITLE
Custom cell templates via component injection

### DIFF
--- a/sp1-custom-table/src/app/app.component.ts
+++ b/sp1-custom-table/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { Table } from './components/custom-table/models/table.model';
 import { CustomTableComponent } from './components/custom-table/custom-table.component';
+import { ButtonCellComponent } from './components/custom-table/cells/button-cell/button-cell.component';
 
 const NAMES = [
   'Hydrogen',
@@ -142,12 +143,21 @@ export class AppComponent {
     id: 'test-table',
     caption: 'User data table with actions.',
     columns: [
-      { field: 'position', header: 'Position', sortable: true, },
+      {
+        field: 'position', header: 'Position', sortable: true, component: ButtonCellComponent,
+        componentInputs: (row) => ({
+          label: `${row.position}`, clickFunc: () => this.buttonClick(row.name)
+        }),
+      },
       { field: 'name', header: 'Name', sortable: true, },
       { field: 'weight', header: 'Weight', sortable: true, },
       { field: 'symbol', header: 'Symbol', sortable: true, },
       { field: 'discoverer', header: 'Discovered By', sortable: true, },
-      { field: 'discoveredLocation', header: 'Discovery Location', valueGetter: (row) => `${row.university} (${row.country})`, sortable: true, },
+      {
+        field: 'discoveredLocation', header: 'Discovery Location',
+        valueGetter: (row) => `${row.university} (${row.country})`,
+        sortable: true,
+      },
       { field: 'career', header: 'Career', sortable: true, },
       { field: 'online', header: 'Online Graduate', },
       { field: 'age', header: 'Age', sortable: true, },
@@ -197,5 +207,9 @@ export class AppComponent {
       married: name.charAt(0) === 'P',
       company: COMPANIES[Math.round(Math.random() * (COMPANIES.length - 1))],
     };
+  }
+
+  private buttonClick(str: string): void {
+    console.log('Button clicked:', str);
   }
 }

--- a/sp1-custom-table/src/app/components/custom-table/cells/button-cell/button-cell.component.spec.ts
+++ b/sp1-custom-table/src/app/components/custom-table/cells/button-cell/button-cell.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ButtonCellComponent } from './button-cell.component';
+
+describe('ButtonCellComponent', () => {
+  let component: ButtonCellComponent;
+  let fixture: ComponentFixture<ButtonCellComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ButtonCellComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ButtonCellComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/sp1-custom-table/src/app/components/custom-table/cells/button-cell/button-cell.component.ts
+++ b/sp1-custom-table/src/app/components/custom-table/cells/button-cell/button-cell.component.ts
@@ -1,0 +1,19 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+
+@Component({
+  selector: 'app-button-cell',
+  standalone: true,
+  imports: [MatButtonModule],
+  template: `
+    <button mat-stroked-button [color]="'accent'" (click)="clickFunc()">
+      <span>{{ label }}</span>
+    </button>
+  `,
+  styleUrl: './button-cell.component.scss'
+})
+export class ButtonCellComponent {
+  @Input() label!: string;
+  @Input() clickFunc!: () => void;
+  @Output() clicked = new EventEmitter<void>();
+}

--- a/sp1-custom-table/src/app/components/custom-table/custom-table.component.html
+++ b/sp1-custom-table/src/app/components/custom-table/custom-table.component.html
@@ -24,7 +24,11 @@
             <th mat-header-cell *matHeaderCellDef mat-sort-header
               sortActionDescription="Sort by {{column.field}}" [disabled]="!column.sortable"> {{ column.header }} </th>
             <td mat-cell *matCellDef="let row" [ngClass]="column.cellClass?.(row) ?? ''">
-              {{ column.valueGetter?.(row) ?? row[column.field] }}
+              @if (column.component) {
+                <ng-container [ngComponentOutlet]="column.component" [ngComponentOutletInputs]="column.componentInputs?.(row)"></ng-container>
+              } @else {
+                {{ column.valueGetter?.(row) ?? row[column.field] }}
+              }
             </td>
           </ng-container>
         }
@@ -34,7 +38,7 @@
           <ng-container matColumnDef="actions" [stickyEnd]="tableConfig.stickyActions">
             <th mat-header-cell *matHeaderCellDef> Actions </th>
             <td mat-cell *matCellDef="let row">
-              <button mat-icon-button [matMenuTriggerFor]="actionMenu">
+              <button mat-icon-button [color]="'accent'" [matMenuTriggerFor]="actionMenu">
                 <mat-icon>more_vert</mat-icon>
               </button>
               <mat-menu #actionMenu="matMenu">

--- a/sp1-custom-table/src/app/components/custom-table/models/column.model.ts
+++ b/sp1-custom-table/src/app/components/custom-table/models/column.model.ts
@@ -1,7 +1,11 @@
+import { Type } from '@angular/core';
+
 export interface Column {
   field: string; // Field name in the data object
   header: string; // Display name of the column
   cellClass?: (row: any) => string | string[]; // Function to determine CSS class for a cell
   valueGetter?: (row: any) => any; // Function to determine the displayed value in the cell
   sortable?: boolean; // Whether the column is sortable
+  component?: Type<any>; // Component to render dynamically
+  componentInputs?: (row: any) => Record<string, unknown>; // Function to determine inputs to pass to the component
 }

--- a/sp1-custom-table/src/styles.scss
+++ b/sp1-custom-table/src/styles.scss
@@ -25,3 +25,8 @@ body {
 .bold {
   font-weight: bold !important;
 }
+
+/* Angular overrides */
+.mdc-button {
+  border-radius: 8px !important;
+}


### PR DESCRIPTION
- ButtonCellComponent for cell template injections
- NgComponentOutlet to inject component templates inside cells
- Expand Column interface to include optional component and componentInputs
    - component of type Type<any> representing a component
    - componentInputs of type function that allows the inputs access to the table row data
- Update .mdc-button border-radius value
- Output emitter for usage later maybe.. idk yet if it's relevant