### PR TITLE
Added support for date range column level filters

### DIFF
--- a/sp1-custom-table/src/app/app.component.ts
+++ b/sp1-custom-table/src/app/app.component.ts
@@ -213,7 +213,7 @@ export class AppComponent {
           header: 'Date of Birth',
           sortable: true,
           filterOptions: {
-            type: 'text',
+            type: 'dateRange',
             filterable: true,
           }
         },
@@ -311,7 +311,7 @@ export class AppComponent {
   }
 
   private generateRandomDateBetween1940AndToday(): string {
-    const startDate = new Date('1940-01-01');
+    const startDate = new Date('2025-01-02');
     const endDate = new Date(); // Today's date
     return formatDate(this.getRandomDate(startDate, endDate), 'MM/dd/yyyy', 'en-US');
   }

--- a/sp1-custom-table/src/app/app.component.ts
+++ b/sp1-custom-table/src/app/app.component.ts
@@ -177,6 +177,9 @@ export class AppComponent {
           field: 'discoveredBy',
           header: 'Discovered By',
           sortable: true,
+          filterOptions: {
+            type: 'text',
+          }
         },
         {
           field: 'discoveryLocation',

--- a/sp1-custom-table/src/app/app.component.ts
+++ b/sp1-custom-table/src/app/app.component.ts
@@ -221,6 +221,14 @@ export class AppComponent {
           field: 'married',
           header: 'Married',
           sortable: true,
+          cellTemplate: 'checkbox',
+          templateInputs(row): Record<string, unknown> {
+            return { checked: row.married };
+          },
+          filterOptions: {
+            type: 'select',
+            filterable: true,
+          }
         },
         {
           field: 'company',
@@ -297,7 +305,7 @@ export class AppComponent {
       career: CAREERS[Math.round(Math.random() * (CAREERS.length - 1))],
       online: pos % 4 === 0,
       dob: this.generateRandomDateBetween1940AndToday(),
-      married: name.charAt(0) === 'P' ? 'Yes' : 'No',
+      married: name.charAt(0) === 'P',
       company: COMPANIES[Math.round(Math.random() * (COMPANIES.length - 1))],
     };
   }

--- a/sp1-custom-table/src/app/app.component.ts
+++ b/sp1-custom-table/src/app/app.component.ts
@@ -150,7 +150,6 @@ export class AppComponent {
           sortable: true,
           filterOptions: {
             type: 'select',
-            filterable: true,
           }
         },
         {
@@ -159,7 +158,6 @@ export class AppComponent {
           sortable: true,
           filterOptions: {
             type: 'text',
-            filterable: true,
             label: 'Filter Weight (>=)',
             filterPredicate: (row: any, filter: string) => {
               const filterNumber = parseInt(filter, 10);
@@ -173,7 +171,6 @@ export class AppComponent {
           sortable: true,
           filterOptions: {
             type: 'select',
-            filterable: true,
           }
         },
         {
@@ -193,7 +190,6 @@ export class AppComponent {
           sortable: true,
           filterOptions: {
             type: 'select',
-            filterable: true,
           }
         },
         {
@@ -205,7 +201,6 @@ export class AppComponent {
           }),
           filterOptions: {
             type: 'select',
-            filterable: true,
           }
         },
         {
@@ -214,7 +209,6 @@ export class AppComponent {
           sortable: true,
           filterOptions: {
             type: 'dateRange',
-            filterable: true,
           }
         },
         {
@@ -227,7 +221,6 @@ export class AppComponent {
           },
           filterOptions: {
             type: 'select',
-            filterable: true,
           }
         },
         {
@@ -236,7 +229,6 @@ export class AppComponent {
           sortable: true,
           filterOptions: {
             type: 'select',
-            filterable: true,
           }
         },
       ],

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.html
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.html
@@ -188,7 +188,7 @@
 </ng-template>
 <!-- Checkbox -->
 <ng-template #checkboxTemplate let-inputs>
-  <mat-checkbox [color]="'primary'" [checked]="inputs.checked" (change)="ignoreCheckboxEvent($event)"></mat-checkbox>
+  <mat-checkbox [color]="'primary'" [checked]="inputs.checked" disabled></mat-checkbox>
 </ng-template>
 
 <!-- Defined Column Filter Templates -->

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.html
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.html
@@ -200,7 +200,10 @@
       (keyup)="sanitize(column.field, filters[column.field])"/>
     @if (filters[column.field]) {
       <button mat-icon-button matSuffix
-        (click)="filters[column.field] = ''; sanitize(column.field, filters[column.field])"
+        (click)="
+          filters[column.field] = '';
+          sanitize(column.field, filters[column.field])
+        "
         [attr.aria-label]="'Clear {{column.header}} filter'">
         <mat-icon>close</mat-icon>
       </button>
@@ -220,37 +223,60 @@
 </ng-template>
 <!-- Date -->
 <ng-template #singleDateFilter let-column let-filters="filters">
-  <mat-form-field class="date-column-filter" appearance="outline">
-    <mat-label> {{ column.filterOptions.label ?? 'Filter by ' + column.header.toLowerCase() }} </mat-label>
-    <input matInput [matDatepicker]="picker"
-      [(ngModel)]="filters[column.field]"
-      [placeholder]="column.filterOptions.placeholder ?? 'Select date'"
-      (dateInput)="sanitize(column.field, filters[column.field])"/>
-
-    @if (filters[column.field]) {
-      <button mat-icon-button matSuffix
-        (click)="filters[column.field] = ''; sanitize(column.field, filters[column.field])"
-        [attr.aria-label]="'Clear {{column.header}} filter'">
-        <mat-icon>close</mat-icon>
-      </button>
-    }
-
-    <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
-    <mat-datepicker #picker></mat-datepicker>
-  </mat-form-field>
+  <form [formGroup]="single">
+    <mat-form-field class="date-column-filter" appearance="outline">
+      <mat-label> {{ column.filterOptions.label ?? 'Filter by ' + column.header.toLowerCase() }} </mat-label>
+      <input matInput [matDatepicker]="picker" formControlName="date" [placeholder]="column.filterOptions.placeholder ?? 'Select date'"
+        (dateInput)="
+          filters[column.field] = $event.value;
+          sanitize(column.field, filters[column.field])
+        "/>
+  
+      @if (filters[column.field]) {
+        <button mat-icon-button matSuffix
+          (click)="
+            filters[column.field] = '';
+            single.reset();
+            sanitize(column.field, filters[column.field])
+          "
+          [attr.aria-label]="'Clear {{column.header}} filter'">
+          <mat-icon>close</mat-icon>
+        </button>
+      }
+  
+      <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
+      <mat-datepicker #picker></mat-datepicker>
+  
+      @if (single.invalid) {
+        <mat-error>Invalid date</mat-error>
+      }
+    </mat-form-field>
+  </form>
 </ng-template>
 <!-- Date range -->
 <ng-template #dateRangeFilter let-column let-filters="filters">
   <mat-form-field appearance="outline">
     <mat-label> {{ column.filterOptions.label ?? 'Filter by ' + column.header.toLowerCase() }} </mat-label>
     <mat-date-range-input [formGroup]="range" [rangePicker]="picker">
-      <input matStartDate formControlName="start" placeholder="Start date" (dateInput)="filters[column.field] = range.value; sanitize(column.field, filters[column.field])">
-      <input matEndDate formControlName="end" placeholder="End date" (dateInput)="filters[column.field] = range.value; sanitize(column.field, filters[column.field])">
+      <input matStartDate formControlName="start" placeholder="Start date"
+        (dateInput)="
+          filters[column.field] = range.value;
+          sanitize(column.field, filters[column.field])
+        ">
+      <input matEndDate formControlName="end" placeholder="End date"
+        (dateInput)="
+          filters[column.field] = range.value;
+          sanitize(column.field, filters[column.field])
+        ">
     </mat-date-range-input>
 
     @if (filters[column.field]) {
       <button mat-icon-button matSuffix
-        (click)="filters[column.field] = ''; range.reset(); sanitize(column.field, filters[column.field])"
+        (click)="
+          filters[column.field] = '';
+          range.reset();
+          sanitize(column.field, filters[column.field])
+        "
         [attr.aria-label]="'Clear {{column.header}} filter'">
         <mat-icon>close</mat-icon>
       </button>

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.html
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.html
@@ -197,10 +197,10 @@
   <mat-form-field appearance="outline">
     <mat-label> {{ column.filterOptions.label ?? 'Filter by ' + column.header.toLowerCase() }} </mat-label>
     <input matInput type="text" [(ngModel)]="filters[column.field]" [placeholder]="column.filterOptions.placeholder ?? ''"
-      (keyup)="applyFilters()"/>
+      (keyup)="sanitize(column.field, filters[column.field])"/>
     @if (filters[column.field]) {
       <button mat-icon-button matSuffix
-        (click)="filters[column.field] = ''; applyFilters()"
+        (click)="filters[column.field] = ''; sanitize(column.field, filters[column.field])"
         [attr.aria-label]="'Clear {{column.header}} filter'">
         <mat-icon>close</mat-icon>
       </button>
@@ -211,7 +211,7 @@
 <ng-template #selectFilter let-column let-filters="filters">
   <mat-form-field appearance="outline">
     <mat-label> {{ column.filterOptions.label ?? 'Filter by ' + column.header.toLowerCase() }} </mat-label>
-    <mat-select [(ngModel)]="filters[column.field]" (selectionChange)="applyFilters()" multiple>
+    <mat-select [(ngModel)]="filters[column.field]" (selectionChange)="sanitize(column.field, filters[column.field])" multiple>
       @for (option of columnSelectFilterOptions[column.field]; track option) {
         <mat-option [value]="option"> {{ option }} </mat-option>
       }
@@ -225,11 +225,11 @@
     <input matInput [matDatepicker]="picker"
       [(ngModel)]="filters[column.field]"
       [placeholder]="column.filterOptions.placeholder ?? 'Select date'"
-      (dateInput)="applyFilters()"/>
+      (dateInput)="sanitize(column.field, filters[column.field])"/>
 
     @if (filters[column.field]) {
       <button mat-icon-button matSuffix
-        (click)="filters[column.field] = ''; applyFilters()"
+        (click)="filters[column.field] = ''; sanitize(column.field, filters[column.field])"
         [attr.aria-label]="'Clear {{column.header}} filter'">
         <mat-icon>close</mat-icon>
       </button>
@@ -244,13 +244,13 @@
   <mat-form-field appearance="outline">
     <mat-label> {{ column.filterOptions.label ?? 'Filter by ' + column.header.toLowerCase() }} </mat-label>
     <mat-date-range-input [formGroup]="range" [rangePicker]="picker">
-      <input matStartDate formControlName="start" placeholder="Start date" (dateInput)="filters[column.field] = range.value; applyFilters()">
-      <input matEndDate formControlName="end" placeholder="End date" (dateInput)="filters[column.field] = range.value; applyFilters()">
+      <input matStartDate formControlName="start" placeholder="Start date" (dateInput)="filters[column.field] = range.value; sanitize(column.field, filters[column.field])">
+      <input matEndDate formControlName="end" placeholder="End date" (dateInput)="filters[column.field] = range.value; sanitize(column.field, filters[column.field])">
     </mat-date-range-input>
 
     @if (filters[column.field]) {
       <button mat-icon-button matSuffix
-        (click)="filters[column.field] = ''; range.reset(); applyFilters()"
+        (click)="filters[column.field] = ''; range.reset(); sanitize(column.field, filters[column.field])"
         [attr.aria-label]="'Clear {{column.header}} filter'">
         <mat-icon>close</mat-icon>
       </button>

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.html
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.html
@@ -117,6 +117,9 @@
                   @case ('date') {
                     <ng-container *ngTemplateOutlet="dateFilter; context: { $implicit: column, filters: columnFilters }"></ng-container>
                   }
+                  @case ('dateRange') {
+                    <ng-container *ngTemplateOutlet="dateRangeFilter; context: { $implicit: column, filters: columnFilters }"></ng-container>
+                  }
                 }
               </th>
             </ng-container>
@@ -223,6 +226,7 @@
       [(ngModel)]="filters[column.field]"
       [placeholder]="column.filterOptions.placeholder ?? 'Select date'"
       (dateInput)="applyFilters()"/>
+
     @if (filters[column.field]) {
       <button mat-icon-button matSuffix
         (click)="filters[column.field] = ''; applyFilters()"
@@ -230,7 +234,37 @@
         <mat-icon>close</mat-icon>
       </button>
     }
+
     <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
     <mat-datepicker #picker></mat-datepicker>
+  </mat-form-field>
+</ng-template>
+<!-- Date range -->
+<ng-template #dateRangeFilter let-column let-filters="filters">
+  <mat-form-field appearance="outline">
+    <mat-label> {{ column.filterOptions.label ?? 'Filter by ' + column.header.toLowerCase() }} </mat-label>
+    <mat-date-range-input [formGroup]="range" [rangePicker]="picker">
+      <input matStartDate formControlName="start" placeholder="Start date" (dateInput)="filters[column.field] = range.value; applyFilters()">
+      <input matEndDate formControlName="end" placeholder="End date" (dateInput)="filters[column.field] = range.value; applyFilters()">
+    </mat-date-range-input>
+
+    @if (filters[column.field]) {
+      <button mat-icon-button matSuffix
+        (click)="filters[column.field] = ''; range.reset(); applyFilters()"
+        [attr.aria-label]="'Clear {{column.header}} filter'">
+        <mat-icon>close</mat-icon>
+      </button>
+    }
+
+    <!-- <mat-hint>MM/DD/YYYY – MM/DD/YYYY</mat-hint> -->
+    <mat-datepicker-toggle matIconSuffix [for]="picker"></mat-datepicker-toggle>
+    <mat-date-range-picker #picker></mat-date-range-picker>
+  
+    @if (range.controls.start.hasError('matStartDateInvalid')) {
+      <mat-error>Invalid start date</mat-error>
+    }
+    @if (range.controls.end.hasError('matEndDateInvalid')) {
+      <mat-error>Invalid end date</mat-error>
+    }
   </mat-form-field>
 </ng-template>

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.html
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.html
@@ -114,8 +114,8 @@
                   @case ('select') {
                     <ng-container *ngTemplateOutlet="selectFilter; context: { $implicit: column, filters: columnFilters }"></ng-container>
                   }
-                  @case ('date') {
-                    <ng-container *ngTemplateOutlet="dateFilter; context: { $implicit: column, filters: columnFilters }"></ng-container>
+                  @case ('singleDate') {
+                    <ng-container *ngTemplateOutlet="singleDateFilter; context: { $implicit: column, filters: columnFilters }"></ng-container>
                   }
                   @case ('dateRange') {
                     <ng-container *ngTemplateOutlet="dateRangeFilter; context: { $implicit: column, filters: columnFilters }"></ng-container>
@@ -219,8 +219,8 @@
   </mat-form-field>
 </ng-template>
 <!-- Date -->
-<ng-template #dateFilter let-column let-filters="filters">
-  <mat-form-field appearance="outline">
+<ng-template #singleDateFilter let-column let-filters="filters">
+  <mat-form-field class="date-column-filter" appearance="outline">
     <mat-label> {{ column.filterOptions.label ?? 'Filter by ' + column.header.toLowerCase() }} </mat-label>
     <input matInput [matDatepicker]="picker"
       [(ngModel)]="filters[column.field]"

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.scss
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.scss
@@ -59,7 +59,7 @@ table {
   }
 
   .mat-mdc-form-field {
-    margin: .5rem auto;
+    margin-top: .625rem;
     min-width: 250px;
   }
 }

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.scss
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.scss
@@ -61,6 +61,14 @@ table {
   .mat-mdc-form-field {
     margin-top: .625rem;
     min-width: 250px;
+
+    &.date-column-filter {
+      min-width: 280px;
+    }
+
+    &.mat-mdc-form-field-type-mat-date-range-input {
+      min-width: 300px;
+    }
   }
 }
 

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.ts
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.ts
@@ -142,7 +142,7 @@ export class CustomTableComponent implements OnChanges, AfterViewInit {
 
       // Apply column-specific filters
       return this.tableConfig.columnsConfig.columns.every((column) => {
-        if (!column.filterOptions || !columnFilters[column.field] || (Array.isArray(columnFilters[column.field]) ? !columnFilters[column.field].length : !Object.keys(columnFilters[column.field]).length)) {
+        if (!column.filterOptions || !columnFilters[column.field]) {
           return true; // Skip columns without active filters
         }
 
@@ -159,7 +159,6 @@ export class CustomTableComponent implements OnChanges, AfterViewInit {
         }
 
         if (column.filterOptions.type === 'dateRange') {
-          console.log('came here');
           const { start, end } = filterValue || {};
           if (start || end) {
             const rowDate = new Date(row[column.field]).getTime();
@@ -191,6 +190,14 @@ export class CustomTableComponent implements OnChanges, AfterViewInit {
 
   protected applyFilter(filterString: string): void {
     this.globalFilter = filterString;
+    this.applyFilters();
+  }
+
+  protected sanitize(column: string, columnFilter: Record<string, string>): void {
+    // If the filter is "empty", delete it to not clutter the output emitted
+    if (this.isEmpty(columnFilter)) {
+      delete this.columnFilters[column];
+    }
     this.applyFilters();
   }
 
@@ -226,4 +233,20 @@ export class CustomTableComponent implements OnChanges, AfterViewInit {
     return this.dataSource._pageData(this.dataSource.data).some((row) => row.selected) &&
       !this.dataSource._pageData(this.dataSource.data).every((row) => row.selected);
   };
+
+  private isEmpty(value: any): boolean {
+    if (value === null || value === undefined) {
+      return true;
+    }
+    if (Array.isArray(value)) {
+      return value.length === 0;
+    }
+    if (typeof value === 'string') {
+      return value.trim().length === 0;
+    }
+    if (typeof value === 'object' && Object.keys(value).length) {
+      return Object.keys(value).every((key) => this.isEmpty(value[key]));
+    }
+    return !value;
+  }
 }

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.ts
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.ts
@@ -54,7 +54,7 @@ export class CustomTableComponent implements OnChanges, AfterViewInit {
     if (changes['tableConfig']?.currentValue) {
       this.generateDisplayColumns();
       // If any column has a filter, generate the filter columns.
-      if (this.tableConfig.columnsConfig.columns.some((col) => col.filterOptions?.filterable)) {
+      if (this.tableConfig.columnsConfig.columns.some((col) => col.filterOptions)) {
         this.generateDisplayColumnsFilters();
       }
       // If table or column-level filters are present, add action to table.
@@ -142,7 +142,7 @@ export class CustomTableComponent implements OnChanges, AfterViewInit {
 
       // Apply column-specific filters
       return this.tableConfig.columnsConfig.columns.every((column) => {
-        if (!column.filterOptions?.filterable || !columnFilters[column.field]) {
+        if (!column.filterOptions || !columnFilters[column.field] || (Array.isArray(columnFilters[column.field]) ? !columnFilters[column.field].length : !Object.keys(columnFilters[column.field]).length)) {
           return true; // Skip columns without active filters
         }
 

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.ts
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.ts
@@ -34,6 +34,9 @@ export class CustomTableComponent implements OnChanges, AfterViewInit {
   displayColumnsFilters: string[] = [];
   columnFilters: Record<string, string> = {}; // Store filters for each column
   columnSelectFilterOptions: Record<string, any[]> = {}; // Store select dropdown filter options for each column
+  readonly single = new FormGroup({
+    date: new FormControl<Date | null>(null),
+  });
   readonly range = new FormGroup({
     start: new FormControl<Date | null>(null),
     end: new FormControl<Date | null>(null),

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.ts
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.ts
@@ -7,7 +7,6 @@ import { MatSort, Sort } from '@angular/material/sort';
 import { LiveAnnouncer } from '@angular/cdk/a11y';
 import { SearchBoxComponent } from '../search-box/search-box.component';
 import { FormControl, FormGroup } from '@angular/forms';
-import { MatCheckboxChange } from '@angular/material/checkbox';
 
 @Component({
   selector: 'app-custom-table',
@@ -206,11 +205,6 @@ export class CustomTableComponent implements OnChanges, AfterViewInit {
 
     // Emit current filters to parent component.
     this.currentFilters.emit(this.columnFilters);
-  }
-
-  protected ignoreCheckboxEvent(event: MatCheckboxChange): void {
-    // Revert checkbox state to "ignore" change event.
-    event.source.checked = !event.checked;
   }
 
   protected selectRow(checked: boolean, row: any): void {

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.module.ts
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.module.ts
@@ -9,7 +9,7 @@ import { MatSortModule } from '@angular/material/sort';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { SearchBoxComponent } from '../search-box/search-box.component';
 import { MAT_FORM_FIELD_DEFAULT_OPTIONS, MatFormFieldDefaultOptions, MatFormFieldModule } from '@angular/material/form-field';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatInputModule } from '@angular/material/input';
 import { MatOptionModule, provideNativeDateAdapter } from '@angular/material/core';
 import { MatSelectModule } from '@angular/material/select';
@@ -39,6 +39,7 @@ const formFieldConfig: MatFormFieldDefaultOptions = {
     MatOptionModule,
     MatDatepickerModule,
     GeneralSpinnerDirective,
+    ReactiveFormsModule,
   ],
   exports: [
     CommonModule,
@@ -57,6 +58,7 @@ const formFieldConfig: MatFormFieldDefaultOptions = {
     MatOptionModule,
     MatDatepickerModule,
     GeneralSpinnerDirective,
+    ReactiveFormsModule
   ],
   providers: [
     { provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: formFieldConfig },

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.module.ts
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.module.ts
@@ -8,17 +8,13 @@ import { MatPaginatorModule } from '@angular/material/paginator';
 import { MatSortModule } from '@angular/material/sort';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { SearchBoxComponent } from '../search-box/search-box.component';
-import { MAT_FORM_FIELD_DEFAULT_OPTIONS, MatFormFieldDefaultOptions, MatFormFieldModule } from '@angular/material/form-field';
+import { MatFormFieldModule } from '@angular/material/form-field';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatInputModule } from '@angular/material/input';
 import { MatOptionModule, provideNativeDateAdapter } from '@angular/material/core';
 import { MatSelectModule } from '@angular/material/select';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { GeneralSpinnerDirective } from '../../directives/general-spinner.directive';
-
-const formFieldConfig: MatFormFieldDefaultOptions = {
-  subscriptSizing: 'dynamic'
-};
 
 @NgModule({
   declarations: [],
@@ -61,7 +57,6 @@ const formFieldConfig: MatFormFieldDefaultOptions = {
     ReactiveFormsModule
   ],
   providers: [
-    { provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: formFieldConfig },
     provideNativeDateAdapter(),
   ]
 })

--- a/sp1-custom-table/src/app/shared/components/custom-table/models/filter.model.ts
+++ b/sp1-custom-table/src/app/shared/components/custom-table/models/filter.model.ts
@@ -1,4 +1,4 @@
-export declare type FilterType = 'text' | 'select' | 'date';
+export declare type FilterType = 'text' | 'select' | 'date' | 'dateRange';
 
 export interface TableFilter {
   id?: string; // ID for filter input element

--- a/sp1-custom-table/src/app/shared/components/custom-table/models/filter.model.ts
+++ b/sp1-custom-table/src/app/shared/components/custom-table/models/filter.model.ts
@@ -9,7 +9,6 @@ export interface TableFilter {
 
 export interface ColumnFilter {
   type: FilterType; // Type of filter
-  filterable: boolean; // Determines if the column has a filter
   label?: string; // Label for filter input
   placeholder?: string; // Placeholder text for filter input
   filterPredicate?: (data: any, filter: string) => boolean; // Custom filter logic

--- a/sp1-custom-table/src/app/shared/components/custom-table/models/filter.model.ts
+++ b/sp1-custom-table/src/app/shared/components/custom-table/models/filter.model.ts
@@ -1,4 +1,4 @@
-export declare type FilterType = 'text' | 'select' | 'date' | 'dateRange';
+export declare type FilterType = 'text' | 'select' | 'singleDate' | 'dateRange';
 
 export interface TableFilter {
   id?: string; // ID for filter input element


### PR DESCRIPTION
- Date range column filters are now supported
- Column filter type 'date' was updated to 'singleDate'
- Filter type 'singleDate' now utilizes a FormGroup because, previously, typing in the date picker would erase input because in-between values resulted in null which then resulted in erasure
- Removed property filterable from ColumnFilter because a column's filterable status is implicit based a required type
- Removed ?.length check inside filterPredicate to function correctly for Arrays, string, Objects, etc. Previously failed for date ranges.
- Removed mat-form-field defaults for better spacing to allow for visual error statements for date pickers
- When column level filters are "empty", they are now removed from the event emitted by CustomTable component. Helps dial down clutter for server side filter requests
- Deleted ignoreCheckboxEvent func for a much simpler disabled directive on the checkbox template
- Rearranged some code and updated some styling