### PR TITLE
43 separate column level filters from td element

### DIFF
--- a/sp1-custom-table/src/app/app.component.html
+++ b/sp1-custom-table/src/app/app.component.html
@@ -9,6 +9,8 @@
       [pageSize]="cPageSize"
       (getData)="tableDataRequestClient()">
     </app-custom-table>
+
+    <mat-divider></mat-divider>
     
     <app-client-paginator
       [accessibleLabel]="accessibleLabel"
@@ -36,6 +38,8 @@
       [pageSize]="sPageSize"
       (getData)="tableDataRequestServer()">
     </app-custom-table>
+
+    <mat-divider></mat-divider>
 
     <app-server-paginator
       [accessibleLabel]="accessibleLabel"

--- a/sp1-custom-table/src/app/app.component.html
+++ b/sp1-custom-table/src/app/app.component.html
@@ -1,5 +1,5 @@
 <!-- Client paging setup -->
-<h2>Client side paged table</h2>
+<!-- <h2>Client side paged table</h2>
 <div class="outer-table-container">
   <div class="table-paginator-container">
     <app-custom-table #clientTable
@@ -22,12 +22,10 @@
       (paginatedData)="updateDataClient($event)">
     </app-client-paginator>
   </div>
-</div>
-
-<!-- <mat-divider></mat-divider> -->
+</div> -->
 
 <!-- Server paging setup -->
-<!-- <h2>Server side paged table</h2>
+<h2>Server side paged table</h2>
 <div class="outer-table-container">
   <div class="table-paginator-container">
     <app-custom-table #serverTable
@@ -51,4 +49,4 @@
       (fetchData)="updateDataServer()">
     </app-server-paginator>
   </div>
-</div> -->
+</div>

--- a/sp1-custom-table/src/app/app.component.ts
+++ b/sp1-custom-table/src/app/app.component.ts
@@ -148,6 +148,7 @@ export class AppComponent implements OnInit {
       reorderColumns: true,
     },
     showRowNumbers: true,
+    multiRowSelection: true,
     autoRefresh: {
       enabled: false,
       intervalMs: AFREFRESH,

--- a/sp1-custom-table/src/app/app.component.ts
+++ b/sp1-custom-table/src/app/app.component.ts
@@ -168,12 +168,14 @@ export class AppComponent implements OnInit {
     tableActions: [
       {
         label: 'Refresh table',
-        description: 'Update tabe with latest data',
+        description: 'Update table with latest data',
         action: () => {
           this.loadData();
           this.tableDataRequestClient();
         }
       },
+    ],
+    selectedRowActions: [
       {
         label: 'Delete rows',
         description: 'Delete selected rows',

--- a/sp1-custom-table/src/app/shared/components/custom-table/child-components/modify-columns/modify-columns.component.html
+++ b/sp1-custom-table/src/app/shared/components/custom-table/child-components/modify-columns/modify-columns.component.html
@@ -30,15 +30,17 @@
 
   <app-span-filler></app-span-filler>
 
-  <div class="action-button">
+  <div class="action-buttons">
     <button mat-flat-button
       (click)="resetColumns()">Reset to default
     </button>
-    <button mat-stroked-button
-      (click)="cancel()">Cancel
-    </button>
-    <button mat-raised-button
-      (click)="close()">Apply Changes
-    </button>
+    <div class="two-buttons">
+      <button mat-stroked-button
+        (click)="cancel()">Cancel
+      </button>
+      <button mat-raised-button
+        (click)="close()">Apply Changes
+      </button>
+    </div>
   </div>
 </div>

--- a/sp1-custom-table/src/app/shared/components/custom-table/child-components/modify-columns/modify-columns.component.scss
+++ b/sp1-custom-table/src/app/shared/components/custom-table/child-components/modify-columns/modify-columns.component.scss
@@ -25,12 +25,20 @@ ul {
   }
 }
 
-.action-button {
+.action-buttons {
   display: flex;
   flex-flow: column wrap;
 
+  .two-buttons {
+    display: flex;
+
+    button {
+      width: 100%;
+    }
+  }
+
   button {
-    margin: .25rem;
+    margin: .125rem;
   }
 }
 

--- a/sp1-custom-table/src/app/shared/components/custom-table/child-components/modify-columns/modify-columns.component.ts
+++ b/sp1-custom-table/src/app/shared/components/custom-table/child-components/modify-columns/modify-columns.component.ts
@@ -127,6 +127,8 @@ export class ModifyColumnsComponent implements OnInit, AfterViewInit {
     const indexMap = new Map<string, number>();
     this.config.columns.forEach((column, i) => indexMap.set(column.field, i));
     this.moddedCols.forEach((col, i) => {
+      // Reset column visibility.
+      col.visible = true;
       let origIndex = indexMap.get(col.field)!;
       while (origIndex !== i) {
         [this.moddedCols[i], this.moddedCols[origIndex]] = [this.moddedCols[origIndex], this.moddedCols[i]];

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.html
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.html
@@ -11,6 +11,39 @@
           [style.z-index]="loading ? 110 : -1"></div>
       
         <div class="table-filter-container">
+          <div class="table-buttons">
+            @if (tableConfig.filterOptions || this.displayColumnsFilters.length > 0) {
+              <button class="smaller-padding"
+                mat-flat-button
+                color="primary"
+                [matTooltip]="resetFiltersTooltip"
+                [attr.aria-label]="resetFiltersTooltip"
+                (click)="resetFilters()">
+                Reset Filters
+              </button>
+            }
+            <button class="smaller-padding" mat-flat-button>Show Filters</button>
+            @if (selectedRows.length > 0) {
+              <button mat-icon-button
+                color="primary"
+                [matTooltip]="multiRowActionMenuTooltip"
+                [matMenuTriggerFor]="selectedRowMenu">
+                <mat-icon>more_vert</mat-icon>
+              </button>
+              <mat-menu #selectedRowMenu="matMenu">
+                @for (action of tableConfig.tableActions; track action) {
+                  <span [class.disabled-wrapper]="action.disabled?.(selectedRows)">
+                    <button mat-menu-item
+                      [attr.aria-label]="action.description"
+                      [disabled]="action.disabled?.(selectedRows)"
+                      (click)="action.action(selectedRows)">
+                      {{ action.label }}
+                    </button>
+                  </span>
+                }
+              </mat-menu>
+            }
+          </div>
           <app-span-filler></app-span-filler>
 
           @if (tableConfig.filterOptions) {

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.html
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.html
@@ -68,7 +68,7 @@
             <!-- Column for multiple row checkbox selection. -->
             @if (tableConfig.multiRowSelection) {
               <ng-container matColumnDef="select">
-                <th class="non-filter-header" mat-header-cell *matHeaderCellDef>
+                <th mat-header-cell *matHeaderCellDef>
                   <mat-checkbox [checked]="allSelected()" [indeterminate]="someSelected()" (change)="toggleAllSelection($event.checked)"></mat-checkbox>
                 </th>
                 <td mat-cell *matCellDef="let row">
@@ -87,7 +87,7 @@
             <!-- Column for numbered rows. -->
             @if (tableConfig.showRowNumbers) {
               <ng-container matColumnDef="#">
-                <th class="non-filter-header" mat-header-cell *matHeaderCellDef> # </th>
+                <th mat-header-cell *matHeaderCellDef> # </th>
                 <td mat-cell *matCellDef="let row; let i = index"> {{ getRowNumber(i) }} </td>
               </ng-container>
       
@@ -102,7 +102,7 @@
             <!-- Columns generated from table configuration. -->
             @for (column of tableConfig.columnsConfig.columns; track column.field) {
               <ng-container matColumnDef="{{ column.field }}">
-                <th class="non-filter-header" mat-header-cell *matHeaderCellDef mat-sort-header
+                <th mat-header-cell *matHeaderCellDef mat-sort-header
                   sortActionDescription="Sort by {{column.field}}" [disabled]="!column.sortable">
                   {{ column.header }}
                 </th>
@@ -165,7 +165,7 @@
             <!-- Column for row actions. -->
             @if (tableConfig.rowActions) {
               <ng-container matColumnDef="actions" [stickyEnd]="tableConfig.rowActions.stickyActions">
-                <th class="non-filter-header" mat-header-cell *matHeaderCellDef> Actions </th>
+                <th mat-header-cell *matHeaderCellDef> Actions </th>
                 <td mat-cell *matCellDef="let row">
                   <button mat-icon-button [color]="'accent'" [matMenuTriggerFor]="actionMenu">
                     <mat-icon>more_vert</mat-icon>
@@ -191,7 +191,7 @@
             }
       
             <!-- Headers -->
-            <tr mat-header-row *matHeaderRowDef="displayColumns; sticky: tableConfig.columnsConfig.stickyHeaders"></tr>
+            <tr class="non-filter-header" mat-header-row *matHeaderRowDef="displayColumns; sticky: tableConfig.columnsConfig.stickyHeaders"></tr>
             @if (displayColumnsFilters.length > 0) {
               <tr mat-header-row *matHeaderRowDef="displayColumnsFilters; sticky: tableConfig.columnsConfig.stickyHeaders"></tr>
             }

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.html
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.html
@@ -91,8 +91,8 @@
 
         @if (columnFiltersPresent) {
           <div class="column-filters-container">
-            @for (column of tableConfig.columnsConfig.columns; track column.field; let i = $index) {
-              @if (column.filterOptions) {
+            @for (column of displayedFilters; track column.field; let i = $index) {
+              @if (column.filterOptions && (column.visible ?? true)) {
                 <div class="column-filter-container">
                   @switch (column.filterOptions.type) {
                     @case ('text') {

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.html
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.html
@@ -15,23 +15,29 @@
             @if (tableConfig.filterOptions || this.displayColumnsFilters.length > 0) {
               <button class="smaller-padding"
                 mat-flat-button
-                color="primary"
+                color="accent"
                 [matTooltip]="resetFiltersTooltip"
                 [attr.aria-label]="resetFiltersTooltip"
                 (click)="resetFilters()">
                 Reset Filters
               </button>
             }
-            <button class="smaller-padding" mat-flat-button>Show Filters</button>
+
+            <button class="smaller-padding"
+              color="accent"
+              mat-flat-button>
+              Show Filters
+            </button>
+
             @if (selectedRows.length > 0) {
               <button mat-icon-button
-                color="primary"
+                color="accent"
                 [matTooltip]="multiRowActionMenuTooltip"
                 [matMenuTriggerFor]="selectedRowMenu">
                 <mat-icon>more_vert</mat-icon>
               </button>
               <mat-menu #selectedRowMenu="matMenu">
-                @for (action of tableConfig.tableActions; track action) {
+                @for (action of tableConfig.selectedRowActions; track action) {
                   <span [class.disabled-wrapper]="action.disabled?.(selectedRows)">
                     <button mat-menu-item
                       [attr.aria-label]="action.description"

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.html
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.html
@@ -12,7 +12,7 @@
       
         <div class="table-filter-container">
           <div class="table-buttons">
-            @if (tableConfig.filterOptions || this.displayColumnsFilters.length > 0) {
+            @if (tableConfig.filterOptions || columnFiltersPresent) {
               <button class="smaller-padding"
                 mat-flat-button
                 color="accent"
@@ -22,12 +22,6 @@
                 Reset Filters
               </button>
             }
-
-            <button class="smaller-padding"
-              color="accent"
-              mat-flat-button>
-              Show Filters
-            </button>
 
             @if (selectedRows.length > 0) {
               <button mat-icon-button
@@ -94,6 +88,43 @@
             </div>
           }
         </div>
+
+        @if (columnFiltersPresent) {
+          <div class="column-filters-container">
+            @for (column of tableConfig.columnsConfig.columns; track column.field; let i = $index) {
+              @if (column.filterOptions) {
+                <div class="column-filter-container">
+                  @switch (column.filterOptions.type) {
+                    @case ('text') {
+                      <ng-container
+                        *ngTemplateOutlet="textFilter;
+                          context: { $implicit: column, filters: columnFilters, inputs: column.filterOptions.templateInputs }">
+                      </ng-container>
+                    }
+                    @case ('select') {
+                      <ng-container
+                        *ngTemplateOutlet="selectFilter;
+                          context: { $implicit: column, filters: columnFilters, inputs: column.filterOptions.templateInputs }">
+                      </ng-container>
+                    }
+                    @case ('singleDate') {
+                      <ng-container
+                        *ngTemplateOutlet="singleDateFilter;
+                          context: { $implicit: column, filters: columnFilters, inputs: column.filterOptions.templateInputs }">
+                      </ng-container>
+                    }
+                    @case ('dateRange') {
+                      <ng-container
+                        *ngTemplateOutlet="dateRangeFilter;
+                          context: { $implicit: column, filters: columnFilters, inputs: column.filterOptions.templateInputs }">
+                      </ng-container>
+                    }
+                  }
+                </div>
+              }
+            }
+          </div>
+        }
       
         <div class="table-container">
           <table mat-table [dataSource]="dataSource" matSort
@@ -114,13 +145,6 @@
                   <mat-checkbox [checked]="row.selected" (change)="selectRow($event.checked, row)"></mat-checkbox>
                 </td>
               </ng-container>
-      
-              <!-- Filter column for multiple row selection. -->
-              @if (displayColumnsFilters.length > 0) {
-                <ng-container matColumnDef="select-filter">
-                  <th mat-header-cell *matHeaderCellDef></th>
-                </ng-container>
-              }
             }
       
             <!-- Column for numbered rows. -->
@@ -129,20 +153,14 @@
                 <th mat-header-cell *matHeaderCellDef> # </th>
                 <td mat-cell *matCellDef="let row; let i = index"> {{ getRowNumber(i) }} </td>
               </ng-container>
-      
-              <!-- Filter column for numbered rows. -->
-              @if (displayColumnsFilters.length > 0) {
-                <ng-container matColumnDef="#-filter">
-                  <th mat-header-cell *matHeaderCellDef></th>
-                </ng-container>
-              }
             }
       
             <!-- Columns generated from table configuration. -->
             @for (column of tableConfig.columnsConfig.columns; track column.field) {
               <ng-container matColumnDef="{{ column.field }}">
                 <th mat-header-cell *matHeaderCellDef mat-sort-header
-                  sortActionDescription="Sort by {{column.field}}" [disabled]="!column.sortable">
+                  sortActionDescription="Sort by {{column.field}}" [disabled]="!column.sortable"
+                  [style.text-align]="column.align">
                   {{ column.header }}
                 </th>
                 <td mat-cell *matCellDef="let row" [ngClass]="column.cellClass?.(row) ?? ''"
@@ -160,45 +178,6 @@
                   }
                 </td>
               </ng-container>
-            }
-      
-            @if (displayColumnsFilters.length > 0) {
-              @for (column of tableConfig.columnsConfig.columns; track column.field; let i = $index) {
-                <ng-container matColumnDef="{{ column.field }}-filter">
-                  <th mat-header-cell *matHeaderCellDef>
-                    @if (column.filterOptions) {
-                      <div class="column-filter-container">
-                        @switch (column.filterOptions.type) {
-                          @case ('text') {
-                            <ng-container
-                              *ngTemplateOutlet="textFilter;
-                                context: { $implicit: column, filters: columnFilters, inputs: column.filterOptions.templateInputs }">
-                            </ng-container>
-                          }
-                          @case ('select') {
-                            <ng-container
-                              *ngTemplateOutlet="selectFilter;
-                                context: { $implicit: column, filters: columnFilters, inputs: column.filterOptions.templateInputs }">
-                            </ng-container>
-                          }
-                          @case ('singleDate') {
-                            <ng-container
-                              *ngTemplateOutlet="singleDateFilter;
-                                context: { $implicit: column, filters: columnFilters, inputs: column.filterOptions.templateInputs }">
-                            </ng-container>
-                          }
-                          @case ('dateRange') {
-                            <ng-container
-                              *ngTemplateOutlet="dateRangeFilter;
-                                context: { $implicit: column, filters: columnFilters, inputs: column.filterOptions.templateInputs }">
-                            </ng-container>
-                          }
-                        }
-                      </div>
-                    }
-                  </th>
-                </ng-container>
-              }
             }
       
             <!-- Column for row actions. -->
@@ -220,20 +199,10 @@
                   </mat-menu>
                 </td>
               </ng-container>
-      
-              <!-- Filter column for row actions. -->
-              @if (displayColumnsFilters.length > 0) {
-                <ng-container matColumnDef="actions-filter" [stickyEnd]="tableConfig.rowActions.stickyActions">
-                  <th mat-header-cell *matHeaderCellDef></th>
-                </ng-container>
-              }
             }
       
             <!-- Headers -->
             <tr class="non-filter-header" mat-header-row *matHeaderRowDef="displayColumns; sticky: tableConfig.columnsConfig.stickyHeaders"></tr>
-            @if (displayColumnsFilters.length > 0) {
-              <tr mat-header-row *matHeaderRowDef="displayColumnsFilters; sticky: tableConfig.columnsConfig.stickyHeaders"></tr>
-            }
 
             <!-- Data rows -->
             <tr mat-row *matRowDef="let row; columns: displayColumns"
@@ -265,7 +234,7 @@
   <app-search-box
     [appearance]="'outline'"
     [id]="'search-' + column"
-    [label]="column.filterOptions.label ?? 'Filter by ' + column.header.toLowerCase()"
+    [label]="column.filterOptions.label ?? 'Filter by ' + column.header"
     [placeholder]="column.filterOptions.placeholder ?? ''"
     [instantSearch]="column.filterOptions.instantSearch ?? false"
     [(value)]="filters[column.field]"
@@ -275,7 +244,7 @@
 <!-- Select -->
 <ng-template #selectFilter let-column let-filters="filters" let-inputs="inputs">
   <mat-form-field appearance="outline">
-    <mat-label> {{ column.filterOptions.label ?? 'Filter by ' + column.header.toLowerCase() }} </mat-label>
+    <mat-label> {{ column.filterOptions.label ?? 'Filter by ' + column.header }} </mat-label>
     <mat-select
       [(ngModel)]="filters[column.field]"
       (selectionChange)="applyFilters()"
@@ -293,7 +262,7 @@
 <ng-template #singleDateFilter let-column let-filters="filters">
   <form [formGroup]="single">
     <mat-form-field class="date-column-filter" appearance="outline">
-      <mat-label> {{ column.filterOptions.label ?? 'Filter by ' + column.header.toLowerCase() }} </mat-label>
+      <mat-label> {{ column.filterOptions.label ?? 'Filter by ' + column.header }} </mat-label>
       <input matInput
         [matDatepicker]="picker"
         formControlName="date"
@@ -327,7 +296,7 @@
 <!-- Date range -->
 <ng-template #dateRangeFilter let-column let-filters="filters">
   <mat-form-field appearance="outline">
-    <mat-label> {{ column.filterOptions.label ?? 'Filter by ' + column.header.toLowerCase() }} </mat-label>
+    <mat-label> {{ column.filterOptions.label ?? 'Filter by ' + column.header }} </mat-label>
     <mat-date-range-input [formGroup]="range" [rangePicker]="picker">
       <input matStartDate
         formControlName="start"

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.scss
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.scss
@@ -5,7 +5,7 @@
 
   .table-buttons {
     display: flex;
-    gap: 2px;
+    gap: .25em;
 
     button.smaller-padding {
       padding: .625em;

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.scss
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.scss
@@ -3,6 +3,15 @@
   display: flex;
   align-items: center;
 
+  .table-buttons {
+    display: flex;
+    gap: 2px;
+
+    button.smaller-padding {
+      padding: .625em;
+    }
+  }
+
   .search-box {
     min-width: 300px;
   }

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.scss
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.scss
@@ -1,5 +1,5 @@
 .table-filter-container {
-  margin: .625rem 0;
+  padding: .625em 0;
   display: flex;
   align-items: center;
 
@@ -31,6 +31,16 @@
   }
 }
 
+.column-filters-container {
+  display: flex;
+  flex-flow: row wrap;
+  column-gap: .5em;
+
+  .column-filter-container {
+    min-width: 300px;
+  }
+}
+
 .table-container {
   margin: 0 auto;
   overflow: auto;
@@ -47,19 +57,6 @@ table {
   tr {
     &.mat-mdc-no-data-row {
       white-space: nowrap;
-    }
-  }
-
-  .column-filter-container {
-    margin-top: .625rem;
-    min-width: 250px;
-
-    &.date-column-filter {
-      min-width: 280px;
-    }
-
-    &.mat-mdc-form-field-type-mat-date-range-input {
-      min-width: 300px;
     }
   }
 }

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.ts
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.ts
@@ -72,7 +72,11 @@ export class CustomTableComponent implements OnChanges {
   private _filterState!: TableFilters | null;
 
   // Selected rows vars.
-  selectedRows!: any[]; // Store selected rows of table.
+  selectedRows: any[] = []; // Store selected rows of table.
+
+  // Tooltip vars.
+  resetFiltersTooltip = 'Clear all filters and search terms';
+  multiRowActionMenuTooltip = 'Show more';
 
   constructor(
     private announcer: LiveAnnouncer,
@@ -127,31 +131,12 @@ export class CustomTableComponent implements OnChanges {
         ];
       }
 
-      // If table or column-level filters are present, add action to table.
-      if (tableConfig.filterOptions || this.displayColumnsFilters.length > 0) {
-        const resetFiltersAction = {
-          label: 'Reset filters',
-          description: 'Clear all filters and search terms',
-          action: () => {
-            this.globalFilter = '';
-            this.searchBox.clear();
-            this.columnFilters = {};
-            this.single.reset();
-            this.range.reset();
-            this.applyFilters();
-          }
-        };
-
-        tableConfig.tableActions = [
-          resetFiltersAction,
-          ...(tableConfig.tableActions || [])
-        ];
-      }
       // Set sort properties if available.
       this.currentSort = {
         active: tableConfig.sortOptions?.initialSort?.active ?? '',
         direction: tableConfig.sortOptions?.initialSort?.direction ?? '',
       };
+
       this.detector.detectChanges();
     }
 
@@ -209,6 +194,15 @@ export class CustomTableComponent implements OnChanges {
     return this.dataSource._pageData(this.dataSource.data).some((row) => row.selected) &&
       !this.dataSource._pageData(this.dataSource.data).every((row) => row.selected);
   };
+
+  protected resetFilters(): void {
+    this.globalFilter = '';
+    this.searchBox.clear();
+    this.columnFilters = {};
+    this.single.reset();
+    this.range.reset();
+    this.applyFilters();
+  }
 
   private _generateDisplayColumns(columns: Column[]): void {
     this.displayColumns = columns.filter(col => col.visible ?? true).map(col => col.field);

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.ts
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.ts
@@ -50,9 +50,8 @@ export class CustomTableComponent implements OnChanges {
 
   // Table column vars.
   displayColumns: string[] = [];
-  displayColumnsFilters: string[] = [];
+  columnFiltersPresent!: boolean;
   columnFilters: Record<string, string> = {}; // Store filters for each column
-  columnSelectFilterOptions: Record<string, any[]> = {}; // Store select dropdown filter options for each column //TODO delete..
   readonly single = new FormGroup({
     date: new FormControl<Date | null>(null),
   });
@@ -91,7 +90,7 @@ export class CustomTableComponent implements OnChanges {
       this._generateDisplayColumns(tableConfig['columnsConfig'].columns);
       // If any column has a filter, generate the filter columns.
       if (tableConfig.columnsConfig.columns.some((col: Column) => col.filterOptions)) {
-        this._generateDisplayColumnsFilters();
+        this.columnFiltersPresent = true;
       }
 
       // If showing and hiding columns is allowed, add action to table.
@@ -115,7 +114,6 @@ export class CustomTableComponent implements OnChanges {
               this.tableConfig.columnsConfig.columns = updatedCols;
               // Update columns.
               this._generateDisplayColumns(updatedCols);
-              this._generateDisplayColumnsFilters();
               // Clean up the subscription and component reference
               sub.unsubscribe();
               modColumns.destroy();
@@ -221,10 +219,6 @@ export class CustomTableComponent implements OnChanges {
     if (this.tableConfig.rowActions) {
       this.displayColumns.push('actions');
     }
-  }
-
-  private _generateDisplayColumnsFilters(): void {
-    this.displayColumnsFilters = this.displayColumns.map(col => `${col}-filter`);
   }
 
   private _isEmpty(value: any): boolean {

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.ts
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.ts
@@ -51,6 +51,7 @@ export class CustomTableComponent implements OnChanges {
   // Table column vars.
   displayColumns: string[] = [];
   columnFiltersPresent!: boolean;
+  displayedFilters!: Column[];
   columnFilters: Record<string, string> = {}; // Store filters for each column
   readonly single = new FormGroup({
     date: new FormControl<Date | null>(null),
@@ -87,7 +88,9 @@ export class CustomTableComponent implements OnChanges {
     if (changes['tableConfig']?.currentValue) {
       const tableConfig = changes['tableConfig'].currentValue;
       // Generate the table display.
-      this._generateDisplayColumns(tableConfig['columnsConfig'].columns);
+      this._generateDisplayColumns(tableConfig.columnsConfig.columns);
+      // Set filters to display.
+      this.displayedFilters = tableConfig.columnsConfig.columns;
       // If any column has a filter, generate the filter columns.
       if (tableConfig.columnsConfig.columns.some((col: Column) => col.filterOptions)) {
         this.columnFiltersPresent = true;
@@ -114,6 +117,8 @@ export class CustomTableComponent implements OnChanges {
               this.tableConfig.columnsConfig.columns = updatedCols;
               // Update columns.
               this._generateDisplayColumns(updatedCols);
+              console.log(updatedCols);
+              this.displayedFilters = updatedCols;
               // Clean up the subscription and component reference
               sub.unsubscribe();
               modColumns.destroy();

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.module.ts
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.module.ts
@@ -18,6 +18,7 @@ import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { ReorderAnimationDirective } from '../../directives/reorder-animation.directive';
 import { SpanFillerComponent } from '../span-filler/span-filler.component';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 @NgModule({
   declarations: [],
@@ -42,6 +43,7 @@ import { SpanFillerComponent } from '../span-filler/span-filler.component';
     MatSidenavModule,
     ReorderAnimationDirective,
     SpanFillerComponent,
+    MatTooltipModule,
   ],
   exports: [
     CommonModule,
@@ -64,6 +66,7 @@ import { SpanFillerComponent } from '../span-filler/span-filler.component';
     MatSidenavModule,
     ReorderAnimationDirective,
     SpanFillerComponent,
+    MatTooltipModule,
   ],
   providers: [
     provideNativeDateAdapter(),

--- a/sp1-custom-table/src/app/shared/components/custom-table/models/actions.model.ts
+++ b/sp1-custom-table/src/app/shared/components/custom-table/models/actions.model.ts
@@ -16,3 +16,10 @@ interface RowAction {
   action: (row: any) => void; // A function executed when the action is triggered
   disabled?: (row: any) => boolean; // A function to determine if the action should be disabled
 }
+
+export interface SelectedRowAction {
+  label: string; // The text label displayed for the action
+  description: string; // Optional description of the action
+  action: (rows?: any[]) => void; // A function executed when the action is triggered
+  disabled?: (rows?: any[]) => boolean; // A function to determine if the action should be disabled
+}

--- a/sp1-custom-table/src/app/shared/components/custom-table/models/table.model.ts
+++ b/sp1-custom-table/src/app/shared/components/custom-table/models/table.model.ts
@@ -1,6 +1,6 @@
 import { TableFilter } from './filter.model';
 import { ColumnsConfig } from './column.model';
-import { RowActionsConfig, TableAction } from './actions.model';
+import { RowActionsConfig, TableAction, SelectedRowAction } from './actions.model';
 import { SortConfig } from './sort.model';
 
 interface AutoRefreshConfig {
@@ -18,7 +18,8 @@ export interface TableConfig {
   autoRefresh?: AutoRefreshConfig; // Configuration for auto refreshing the table
   rowClass?: (row: any) => string | string[]; // Function to determine CSS class for a row
   sortOptions?: SortConfig; // Configuration for sorting
-  tableActions?: TableAction[]; // Array of table actions. Some batch row action or clearing all filters.
+  tableActions?: TableAction[]; // Array of table actions.
+  selectedRowActions?: SelectedRowAction[]; // Array of actions that can be done in batches.
   rowActions?: RowActionsConfig; // Configuration for row actions
   filterOptions?: TableFilter; // Configuration for table filter
 }


### PR DESCRIPTION
- Column level filters:
    - No longer exist inside the table. They are under the table search portion.
    - Are linked with the current view of the table, so that when a column is hidden, so is its filter.
- Top section of table changed to separate out the concept table actions into 2 sections:
    - Multi-row actions (new interface SelectedRowAction) are not only shown once a row/multiple rows are selected.
    - Table actions are inside the gear icon of the table now.