### PR TITLE
49 flatten nested objects into column objects

### DIFF
--- a/sp1-custom-table/src/app/app.component.html
+++ b/sp1-custom-table/src/app/app.component.html
@@ -1,5 +1,5 @@
 <!-- Client paging setup -->
-<!-- <h2>Client side paged table</h2>
+<h2>Client side paged table</h2>
 <div class="outer-table-container">
   <div class="table-paginator-container">
     <app-custom-table #clientTable
@@ -22,10 +22,10 @@
       (paginatedData)="updateDataClient($event)">
     </app-client-paginator>
   </div>
-</div> -->
+</div>
 
 <!-- Server paging setup -->
-<h2>Server side paged table</h2>
+<!-- <h2>Server side paged table</h2>
 <div class="outer-table-container">
   <div class="table-paginator-container">
     <app-custom-table #serverTable
@@ -49,4 +49,4 @@
       (fetchData)="updateDataServer()">
     </app-server-paginator>
   </div>
-</div>
+</div> -->

--- a/sp1-custom-table/src/app/app.component.ts
+++ b/sp1-custom-table/src/app/app.component.ts
@@ -9,6 +9,7 @@ import { AsyncPipe } from '@angular/common';
 import { MatDividerModule } from '@angular/material/divider';
 import { FlattenToColumnService } from './shared/components/custom-table/services/flatten-to-column.service';
 import { Column } from './shared/components/custom-table/models/column.model';
+import { PathValuePipe } from './shared/pipes/path-value.pipe';
 
 const AFREFRESH = 2000;
 
@@ -17,7 +18,8 @@ const AFREFRESH = 2000;
   standalone: true,
   imports: [CustomTableComponent, ClientPaginatorComponent, ServerPaginatorComponent, AsyncPipe, MatDividerModule],
   templateUrl: './app.component.html',
-  styleUrl: './app.component.scss'
+  styleUrl: './app.component.scss',
+  providers: [PathValuePipe],
 })
 export class AppComponent implements OnInit {
   @ViewChild('clientTable') clientTable!: CustomTableComponent;
@@ -244,6 +246,7 @@ export class AppComponent implements OnInit {
     private mockService: MockDataService,
     private detector: ChangeDetectorRef,
     private flattenService: FlattenToColumnService,
+    private pvp: PathValuePipe,
   ) {
     this.loading = true;
     // Mock server data retrieval wait.
@@ -283,7 +286,7 @@ export class AppComponent implements OnInit {
           sortable: false,
           align: 'center',
           visible: true,
-          checked: (row: any) => row[path],
+          checked: (row: any) => this.pvp.transform<typeof row, boolean>(row, path) ?? false,
         };
       }
       return {

--- a/sp1-custom-table/src/app/app.component.ts
+++ b/sp1-custom-table/src/app/app.component.ts
@@ -293,7 +293,7 @@ export class AppComponent implements OnInit {
         type: 'text',
         field: path,
         header: path,
-        sortable: false,
+        sortable: true,
         visible: true,
       };
     };

--- a/sp1-custom-table/src/app/mock-data.service.ts
+++ b/sp1-custom-table/src/app/mock-data.service.ts
@@ -341,9 +341,9 @@ export class MockDataService {
       married: name.charAt(0) === 'P',
       company: COMPANIES[Math.round(Math.random() * (COMPANIES.length - 1))],
       address: {
-        street: '123 Main St',
-        city: 'Anytown',
-        zip: '12345',
+        street: index % 4 ? '123 Main St' : '456 Elm Streat',
+        city: index % 4 ? 'Anytown' : 'Hereville',
+        zip: index % 4 ? '12345' : '78910',
       },
       preferences: {
         newsletter: true,

--- a/sp1-custom-table/src/app/mock-data.service.ts
+++ b/sp1-custom-table/src/app/mock-data.service.ts
@@ -44,6 +44,15 @@ export interface MockModel {
   dob: string;
   married: boolean;
   company: string;
+  address: {
+    street: string;
+    city: string;
+    zip: string;
+  };
+  preferences: {
+    newsletter: boolean;
+    notifications: boolean;
+  };
 }
 
 export interface MockResponse {
@@ -331,6 +340,15 @@ export class MockDataService {
       dob: this.generateRandomDateBetween1940AndToday(),
       married: name.charAt(0) === 'P',
       company: COMPANIES[Math.round(Math.random() * (COMPANIES.length - 1))],
+      address: {
+        street: '123 Main St',
+        city: 'Anytown',
+        zip: '12345',
+      },
+      preferences: {
+        newsletter: true,
+        notifications: false,
+      },
     };
   }
 

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.html
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.html
@@ -171,7 +171,7 @@
                       <ng-container *ngTemplateOutlet="checkboxTemplate; context: {checked: column.checked, row: row}"></ng-container>
                     }
                     @default {
-                      {{ column.valueGetter?.(row) ?? row[column.field] }}
+                      {{ column.valueGetter?.(row) ?? row | pathValue: column.field }}
                     }
                   }
                 </td>

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.scss
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.scss
@@ -9,6 +9,7 @@
   }
 
   .table-search-bar {
+    width: 600px;
     min-width: 300px;
   }
 

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.module.ts
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.module.ts
@@ -19,6 +19,7 @@ import { ReorderAnimationDirective } from '../../directives/reorder-animation.di
 import { SpanFillerComponent } from '../span-filler/span-filler.component';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { SearchBarComponent } from '../search-bar/search-bar.component';
+import { PathValuePipe } from '../../pipes/path-value.pipe';
 
 @NgModule({
   declarations: [],
@@ -44,6 +45,7 @@ import { SearchBarComponent } from '../search-bar/search-bar.component';
     SpanFillerComponent,
     MatTooltipModule,
     SearchBarComponent,
+    PathValuePipe,
   ],
   exports: [
     CommonModule,
@@ -67,6 +69,7 @@ import { SearchBarComponent } from '../search-bar/search-bar.component';
     SpanFillerComponent,
     MatTooltipModule,
     SearchBarComponent,
+    PathValuePipe,
   ],
   providers: [
     provideNativeDateAdapter(),

--- a/sp1-custom-table/src/app/shared/components/custom-table/services/flatten-to-column.service.spec.ts
+++ b/sp1-custom-table/src/app/shared/components/custom-table/services/flatten-to-column.service.spec.ts
@@ -1,0 +1,138 @@
+import { TestBed } from '@angular/core/testing';
+import { FlattenToColumnService } from './flatten-to-column.service';
+import { Column } from '../models/column.model';
+
+describe('FlattenToColumnService', () => {
+  let service: FlattenToColumnService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(FlattenToColumnService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should flatten a simple object into columns', () => {
+    const obj = {
+      id: 1,
+      name: 'John Doe',
+    };
+
+    const determineColumnType = (key: string, _value: any, path: string): Column<any> => ({
+      type: 'text',
+      field: path,
+      header: key,
+      sortable: true,
+      visible: true,
+    });
+
+    const columns = service.flattenObjectToColumns(obj, determineColumnType);
+
+    expect(columns).toEqual([
+      { type: 'text', field: 'id', header: 'id', sortable: true, visible: true },
+      { type: 'text', field: 'name', header: 'name', sortable: true, visible: true },
+    ]);
+  });
+
+  it('should flatten a nested object into columns with dot notation', () => {
+    const obj = {
+      id: 1,
+      name: 'John Doe',
+      address: {
+        street: '123 Main St',
+        city: 'Anytown',
+      },
+    };
+
+    const determineColumnType = (key: string, value: any, path: string): Column<any> => ({
+      type: 'text',
+      field: path,
+      header: key,
+      sortable: true,
+      visible: true,
+    });
+
+    const columns = service.flattenObjectToColumns(obj, determineColumnType);
+
+    expect(columns).toEqual([
+      { type: 'text', field: 'id', header: 'id', sortable: true, visible: true },
+      { type: 'text', field: 'name', header: 'name', sortable: true, visible: true },
+      { type: 'text', field: 'address.street', header: 'street', sortable: true, visible: true },
+      { type: 'text', field: 'address.city', header: 'city', sortable: true, visible: true },
+    ]);
+  });
+
+  it('should merge new columns with existing columns', () => {
+    const existingColumns: Column<any>[] = [
+      {
+        type: 'text',
+        field: 'id',
+        header: 'ID',
+        sortable: true,
+        visible: true,
+      },
+    ];
+
+    const obj = {
+      name: 'John Doe',
+      address: {
+        city: 'Anytown',
+      },
+    };
+
+    const determineColumnType = (key: string, value: any, path: string): Column<any> => ({
+      type: 'text',
+      field: path,
+      header: key,
+      sortable: true,
+      visible: true,
+    });
+
+    const mergedColumns = service.flattenAndMergeColumns(obj, determineColumnType, existingColumns);
+
+    expect(mergedColumns).toEqual([
+      { type: 'text', field: 'id', header: 'ID', sortable: true, visible: true },
+      { type: 'text', field: 'name', header: 'name', sortable: true, visible: true },
+      { type: 'text', field: 'address.city', header: 'city', sortable: true, visible: true },
+    ]);
+  });
+
+  it('should return an empty array for an empty object', () => {
+    const obj = {};
+
+    const determineColumnType = (key: string, value: any, path: string): Column<any> => ({
+      type: 'text',
+      field: path,
+      header: key,
+      sortable: true,
+      visible: true,
+    });
+
+    const columns = service.flattenObjectToColumns(obj, determineColumnType);
+
+    expect(columns).toEqual([]);
+  });
+
+  it('should handle invalid fields gracefully', () => {
+    const obj = {
+      id: 1,
+      name: 'John Doe',
+    };
+
+    const determineColumnType = (key: string, value: any, path: string): Column<any> => ({
+      type: 'text',
+      field: path,
+      header: key,
+      sortable: true,
+      visible: true,
+    });
+
+    const columns = service.flattenObjectToColumns(obj, determineColumnType);
+
+    // Attempt to access a non-existent field
+    const invalidField = columns.find((col) => col.field === 'invalid');
+    expect(invalidField).toBeUndefined();
+  });
+});

--- a/sp1-custom-table/src/app/shared/components/custom-table/services/flatten-to-column.service.ts
+++ b/sp1-custom-table/src/app/shared/components/custom-table/services/flatten-to-column.service.ts
@@ -1,0 +1,221 @@
+import { Injectable } from '@angular/core';
+import { Column } from '../models/column.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class FlattenToColumnService {
+  /**
+   * Flattens an object into an array of Column objects.
+   * @template T - The type of the rows in the table.
+   * @param {Record<string, any>} obj - The object to flatten.
+   * @param {(key: string, value: any, path: string) => Column<T>} determineColumnType - Callback to determine the column type.
+   * @param {string} [prefix=''] - The prefix for nested fields (used internally for recursion).
+   * @returns {Column<T>[]} - An array of Column objects.
+   * @example
+   * const nestedObject = { id: 1, name: 'John Doe' };
+   * const determineColumnType = (key, value, path) => ({
+   *   type: 'text',
+   *   field: path,
+   *   header: key,
+   *   sortable: true,
+   *   visible: true,
+   * });
+   * const columns = flattenObjectToColumns(nestedObject, determineColumnType);
+   * console.log(columns);
+   */
+  flattenObjectToColumns<T>(
+    obj: Record<string, any>,
+    determineColumnType: (key: string, value: any, path: string) => Column<T>,
+    prefix = ''
+  ): Column<T>[] {
+    const columns: Column<T>[] = [];
+
+    for (const key in obj) {
+      if (Object.prototype.hasOwnProperty.call(obj, key)) {
+        const fullPath = prefix ? `${prefix}.${key}` : key;
+
+        if (typeof obj[key] === 'object' && !Array.isArray(obj[key])) {
+          // Recursively flatten nested objects
+          columns.push(...this.flattenObjectToColumns(obj[key], determineColumnType, fullPath));
+        } else {
+          // Use the callback to determine the column type
+          const column = determineColumnType(key, obj[key], fullPath);
+          columns.push(column);
+        }
+      }
+    }
+
+    return columns;
+  }
+
+  /**
+   * Flattens an object into an array of Column objects and merges them with an existing array of columns.
+   * @template T - The type of the rows in the table.
+   * @param {Record<string, any>} obj - The object to flatten.
+   * @param {(key: string, value: any, path: string) => Column<T>} determineColumnType - Callback to determine the column type.
+   * @param {string} [prefix=''] - The prefix for nested fields (used internally for recursion).
+   * @param {Column<T>[]} existingColumns - Existing array of Column objects to merge with.
+   * @returns {Column<T>[]} - A merged array of Column objects.
+   * @example
+   * // Existing columns
+   * const existingColumns = [
+   *   {
+   *     type: 'button',
+   *     field: 'position',
+   *     header: 'Position',
+   *     align: 'center',
+   *     label: (row) => String(row.position),
+   *     onClick: (row) => console.log('Position:', row.position),
+   *     visible: false,
+   *   },
+   *   {
+   *     type: 'checkbox',
+   *     field: 'isActive',
+   *     header: 'Active',
+   *     sortable: true,
+   *     visible: true,
+   *     checked: (row) => row.isActive,
+   *     onChange: (checked, row) => console.log('Active status changed:', checked, row),
+   *   },
+   * ];
+   *
+   * // Example object to flatten
+   * const nestedObject = {
+   *   id: 1,
+   *   name: 'John Doe',
+   *   address: {
+   *     street: '123 Main St',
+   *     city: 'Anytown',
+   *     zip: '12345',
+   *   },
+   *   preferences: {
+   *     newsletter: true,
+   *     notifications: false,
+   *   },
+   *   actions: 'Edit', // Example field for a ButtonColumn
+   * };
+   *
+   * // Callback to determine the column type dynamically
+   * const determineColumnType = (key, value, path) => {
+   *   if (key === 'actions') {
+   *     return {
+   *       type: 'button',
+   *       field: path,
+   *       header: key,
+   *       sortable: false,
+   *       visible: true,
+   *       label: (row) => 'Click Me',
+   *       onClick: (row) => console.log('Button clicked', row),
+   *     };
+   *   } else if (typeof value === 'boolean') {
+   *     return {
+   *       type: 'checkbox',
+   *       field: path,
+   *       header: key,
+   *       sortable: true,
+   *       visible: true,
+   *       checked: (row) => row[path],
+   *       onChange: (checked, row) => console.log('Checkbox changed', checked, row),
+   *     };
+   *   } else {
+   *     return {
+   *       type: 'text',
+   *       field: path,
+   *       header: key,
+   *       sortable: true,
+   *       visible: true,
+   *     };
+   *   }
+   * };
+   *
+   * // Flatten the object and merge with existing columns
+   * const mergedColumns = flattenAndMergeColumns(nestedObject, determineColumnType, existingColumns);
+   * console.log(mergedColumns);
+   * // Output:
+   * // [
+   * //   {
+   * //     type: 'button',
+   * //     field: 'position',
+   * //     header: 'Position',
+   * //     align: 'center',
+   * //     label: (row) => String(row.position),
+   * //     onClick: (row) => console.log('Position:', row.position),
+   * //     visible: false,
+   * //   },
+   * //   {
+   * //     type: 'checkbox',
+   * //     field: 'isActive',
+   * //     header: 'Active',
+   * //     sortable: true,
+   * //     visible: true,
+   * //     checked: (row) => row.isActive,
+   * //     onChange: (checked, row) => console.log('Active status changed:', checked, row),
+   * //   },
+   * //   { type: 'text', field: 'id', header: 'id', sortable: true, visible: true },
+   * //   { type: 'text', field: 'name', header: 'name', sortable: true, visible: true },
+   * //   { type: 'text', field: 'address.street', header: 'street', sortable: true, visible: true },
+   * //   { type: 'text', field: 'address.city', header: 'city', sortable: true, visible: true },
+   * //   { type: 'text', field: 'address.zip', header: 'zip', sortable: true, visible: true },
+   * //   {
+   * //     type: 'checkbox',
+   * //     field: 'preferences.newsletter',
+   * //     header: 'newsletter',
+   * //     sortable: true,
+   * //     visible: true,
+   * //     checked: (row) => row['preferences.newsletter'],
+   * //     onChange: (checked, row) => console.log('Checkbox changed', checked, row),
+   * //   },
+   * //   {
+   * //     type: 'checkbox',
+   * //     field: 'preferences.notifications',
+   * //     header: 'notifications',
+   * //     sortable: true,
+   * //     visible: true,
+   * //     checked: (row) => row['preferences.notifications'],
+   * //     onChange: (checked, row) => console.log('Checkbox changed', checked, row),
+   * //   },
+   * //   {
+   * //     type: 'button',
+   * //     field: 'actions',
+   * //     header: 'actions',
+   * //     sortable: false,
+   * //     visible: true,
+   * //     label: (row) => 'Click Me',
+   * //     onClick: (row) => console.log('Button clicked', row),
+   * //   },
+   * // ]
+   */
+  flattenAndMergeColumns<T>(
+    obj: Record<string, any>,
+    determineColumnType: (key: string, value: any, path: string) => Column<T>,
+    existingColumns: Column<T>[],
+    prefix?: string
+  ): Column<T>[] {
+    // Flatten the object into new columns
+    const newColumns = (prefix === undefined)
+      ? this.flattenObjectToColumns(obj, determineColumnType)
+      : this.flattenObjectToColumns(obj, determineColumnType, prefix);
+
+    // Merge new columns with existing columns
+    const mergedColumns = [...existingColumns]; // Start with existing columns
+
+    for (const newColumn of newColumns) {
+      // Check if a column with the same field already exists
+      const existingColumnIndex = mergedColumns.findIndex((col) => col.field === newColumn.field);
+
+      if (existingColumnIndex === -1) {
+        // If the column doesn't exist, add it
+        mergedColumns.push(newColumn);
+      } else {
+        // If the column exists, merge the properties (optional: override or combine)
+        mergedColumns[existingColumnIndex] = {
+          ...mergedColumns[existingColumnIndex], // Keep existing properties
+          ...newColumn, // Override with new properties
+        };
+      }
+    }
+
+    return mergedColumns;
+  }
+}

--- a/sp1-custom-table/src/app/shared/pipes/path-value.pipe.spec.ts
+++ b/sp1-custom-table/src/app/shared/pipes/path-value.pipe.spec.ts
@@ -1,0 +1,86 @@
+import { PathValuePipe } from './path-value.pipe';
+
+describe('PathValuePipe', () => {
+  let pipe: PathValuePipe;
+
+  beforeEach(() => {
+    pipe = new PathValuePipe();
+  });
+
+  it('should create an instance', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  it('should return a direct property value', () => {
+    const obj = { name: 'Alice' };
+    expect(pipe.transform<typeof obj, string>(obj, 'name')).toBe('Alice');
+  });
+
+  it('should return a nested property value', () => {
+    const obj = { user: { address: { city: 'New York' } } };
+    expect(pipe.transform<typeof obj, string>(obj, 'user.address.city')).toBe('New York');
+  });
+
+  it('should return undefined for a missing property', () => {
+    const obj = { user: { address: {} } };
+    expect(pipe.transform<typeof obj, string>(obj, 'user.address.city')).toBeUndefined();
+  });
+
+  it('should return undefined if the field path is empty', () => {
+    const obj = { user: { name: 'Alice' } };
+    expect(pipe.transform<typeof obj, string>(obj, '')).toBeUndefined();
+  });
+
+  it('should return undefined if the object is null', () => {
+    expect(pipe.transform<null, string>(null, 'name')).toBeUndefined();
+  });
+
+  it('should return undefined if the object is undefined', () => {
+    expect(pipe.transform<undefined, string>(undefined, 'name')).toBeUndefined();
+  });
+
+  it('should return undefined if the path contains an invalid key', () => {
+    const obj = { user: { name: 'Alice' } };
+    expect(pipe.transform<typeof obj, string>(obj, 'user.age')).toBeUndefined();
+  });
+
+  it('should return an array value if the path points to an array', () => {
+    const obj = { users: [{ name: 'Alice' }, { name: 'Bob' }] };
+    expect(pipe.transform<typeof obj, { name: string }[]>(obj, 'users')?.length).toBe(2);
+  });
+
+  it('should return a value from an array by index', () => {
+    const obj = { users: [{ name: 'Alice' }, { name: 'Bob' }] };
+    expect(pipe.transform<typeof obj, string>(obj, 'users.1.name')).toBe('Bob');
+  });
+
+  it('should return undefined if an array index is out of bounds', () => {
+    const obj = { users: [{ name: 'Alice' }] };
+    expect(pipe.transform<typeof obj, string>(obj, 'users.2.name')).toBeUndefined();
+  });
+
+  it('should handle objects with non-string keys', () => {
+    const obj = { '123': { name: 'Alice' } };
+    expect(pipe.transform<typeof obj, string>(obj, '123.name')).toBe('Alice');
+  });
+
+  it('should work with boolean values', () => {
+    const obj = { isActive: true };
+    expect(pipe.transform<typeof obj, boolean>(obj, 'isActive')).toBeTrue();
+  });
+
+  it('should work with number values', () => {
+    const obj = { age: 30 };
+    expect(pipe.transform<typeof obj, number>(obj, 'age')).toBe(30);
+  });
+
+  it('should work with null values in the object', () => {
+    const obj = { user: { name: null } };
+    expect(pipe.transform<typeof obj, null>(obj, 'user.name')).toBeNull();
+  });
+
+  it('should return undefined if accessing a nested property on a null value', () => {
+    const obj = { user: { name: null } };
+    expect(pipe.transform<typeof obj, string>(obj, 'user.name.first')).toBeUndefined();
+  });
+});

--- a/sp1-custom-table/src/app/shared/pipes/path-value.pipe.ts
+++ b/sp1-custom-table/src/app/shared/pipes/path-value.pipe.ts
@@ -1,0 +1,35 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'pathValue',
+  standalone: true,
+  pure: true // Ensures efficient change detection
+})
+export class PathValuePipe implements PipeTransform {
+  /**
+   * Extracts a nested value from an object using a dot-notated field path.
+   *
+   * @template T - The type of the input object.
+   * @template K - The expected return type of the value.
+   * @param {T} row - The object to retrieve the value from.
+   * @param {string} field - The dot-notated path to the property.
+   * @returns {K | undefined} - The extracted value or undefined if not found.
+   *
+   * @example
+   * // In a component:
+   * const user = { name: 'Alice', address: { city: 'New York' } };
+   * const city = this.pathValuePipe.transform<typeof user, string>(user, 'address.city');
+   * console.log(city); // Outputs: 'New York'
+   *
+   * // In a template:
+   * {{ user | pathValue:'address.city' }} <!-- Outputs 'New York' -->
+   */
+  transform<T, K>(row: T, field: string): K | undefined {
+    // Handle empty cases
+    if (!row || !field) return undefined;
+
+    return field.split('.').reduce<any>((obj, key) => {
+      return obj && typeof obj === 'object' && key in obj ? obj[key] : undefined;
+    }, row) as K;
+  }
+}


### PR DESCRIPTION
- Added pivotal FlattenToColumn to unravel an object
    - Provides:
        - flattenObjectToColumns which unravels an object into an array of Columns
        - flattenAndMergeColumns which will unravel an object and then merge its resulting columns into an array of Columns
- Added PathValuePipe which can traverse an object via path and return its value
- Increase table search bar width