### PR TITLE
65 srp violation fixes

### DIFF
--- a/sp1-custom-table/src/app/app.component.html
+++ b/sp1-custom-table/src/app/app.component.html
@@ -7,7 +7,6 @@
       [tableData]="paginatedData"
       [pageIndex]="cPageIndex"
       [pageSize]="cPageSize"
-      (getData)="tableDataRequestClient()"
       (filterChange)="clientFilterChanged($event)"
       (sortChange)="clientSortChanged($event)">
     </app-custom-table>

--- a/sp1-custom-table/src/app/app.component.html
+++ b/sp1-custom-table/src/app/app.component.html
@@ -7,7 +7,8 @@
       [tableData]="paginatedData"
       [pageIndex]="cPageIndex"
       [pageSize]="cPageSize"
-      (getData)="tableDataRequestClient()">
+      (getData)="tableDataRequestClient()"
+      (filterChange)="clientFilterChanged($event)">
     </app-custom-table>
 
     <mat-divider></mat-divider>

--- a/sp1-custom-table/src/app/app.component.html
+++ b/sp1-custom-table/src/app/app.component.html
@@ -8,7 +8,8 @@
       [pageIndex]="cPageIndex"
       [pageSize]="cPageSize"
       (getData)="tableDataRequestClient()"
-      (filterChange)="clientFilterChanged($event)">
+      (filterChange)="clientFilterChanged($event)"
+      (sortChange)="clientSortChanged($event)">
     </app-custom-table>
 
     <mat-divider></mat-divider>

--- a/sp1-custom-table/src/app/app.component.ts
+++ b/sp1-custom-table/src/app/app.component.ts
@@ -195,6 +195,10 @@ export class AppComponent implements OnInit {
   cPageSize = 10;
   cPageSizeOptions = [10, 20, 40, 80, 100];
 
+  // Client filter var.
+  clientFilter = '';
+  // Client sort var.
+
   // Server paging vars.
   sPageIndex = 0;
   sPageSize = 10;
@@ -204,7 +208,7 @@ export class AppComponent implements OnInit {
   loading!: boolean;
 
   // Auto-refresh vars.
-  private _refreshIntervalId!: ReturnType<typeof setTimeout>;;
+  _refreshIntervalId!: ReturnType<typeof setTimeout>;;
 
   constructor(
     private mockService: MockDataService,
@@ -278,7 +282,7 @@ export class AppComponent implements OnInit {
     this.detector.detectChanges();
   }
 
-  protected updateDataClient(newData: MockModel[]): void {
+  updateDataClient(newData: MockModel[]): void {
     this.paginatedData = [...newData];
     if (this.clientPaginator) {
       // Interesting reassignment with destructuring ..
@@ -287,7 +291,7 @@ export class AppComponent implements OnInit {
     this.detector.detectChanges();
   }
 
-  protected updateDataServer(): void {
+  updateDataServer(): void {
     this.loading = true;
     ({ pageIndex: this.sPageIndex, pageSize: this.sPageSize } = this.serverPaginator.getPagination());
 
@@ -311,17 +315,17 @@ export class AppComponent implements OnInit {
     }, this._getRandomNumber(275, 1000));
   }
 
-  protected tableDataRequestClient(): void {
-    const filteredData = [...this.clientData];
+  tableDataRequestClient(): void {
+    let filteredData = [...this.clientData];
     const sort = this.clientTable.getSort();
 
     // Store filtering and sorting options.
-    // const globalFilter = '';
+    const globalFilter = this.clientFilter;
     const sortBy = sort?.active;
     const sortDirection = sort?.direction;
 
     // Apply global filter, if provided
-    /* if (globalFilter) {
+    if (globalFilter) {
       const searchTerm = globalFilter.toLowerCase();
       filteredData = filteredData.filter((item) =>
         Object.values(item).some((value) =>
@@ -330,7 +334,7 @@ export class AppComponent implements OnInit {
           value.toString().toLowerCase().includes(searchTerm)
         )
       );
-    } */
+    }
 
     // Sort if sortBy is provided
     if (sortBy) {
@@ -370,7 +374,7 @@ export class AppComponent implements OnInit {
     this.clientPaginator.pageIndex = validatedPage;
   }
 
-  protected tableDataRequestServer(): void {
+  tableDataRequestServer(): void {
 
     this.loading = true;
     // Reset if paginator knows the data limit.
@@ -396,7 +400,7 @@ export class AppComponent implements OnInit {
     }, this._getRandomNumber(275, 1000));
   }
 
-  protected toggleAutoRefresh(enabled: boolean): void {
+  toggleAutoRefresh(enabled: boolean): void {
     if (enabled) {
       this.stopAF();
     } else {
@@ -404,22 +408,27 @@ export class AppComponent implements OnInit {
     }
   }
 
-  protected startAF(): void {
+  startAF(): void {
     this._refreshIntervalId = setInterval(() => {
       this.loadData();
       this.tableDataRequestClient();
     }, this.tableConfig.autoRefresh?.intervalMs);
   }
 
-  protected stopAF(): void {
+  stopAF(): void {
     clearInterval(this._refreshIntervalId);
   }
 
-  private _getRandomNumber(min: number, max: number): number {
+  clientFilterChanged(filterStr: string): void {
+    this.clientFilter = filterStr;
+    this.tableDataRequestClient();
+  }
+
+  _getRandomNumber(min: number, max: number): number {
     return Math.floor(Math.random() * (max - min + 1)) + min;
   }
 
-  private _getFlattenedHeader(path: string): string {
+  _getFlattenedHeader(path: string): string {
     const parts = path.split('.').map<string>(str => str.charAt(0).toUpperCase() + str.slice(1));
     if (parts.length === 1) {
       return parts[0];

--- a/sp1-custom-table/src/app/app.component.ts
+++ b/sp1-custom-table/src/app/app.component.ts
@@ -47,10 +47,6 @@ export class AppComponent implements OnInit {
           field: 'name',
           header: 'Name',
           sortable: true,
-          filterOptions: {
-            type: 'select',
-            options: () => Array.from(new Set<string>(this.clientData?.map(e => e.name))).sort(),
-          }
         },
         {
           type: 'text',
@@ -64,21 +60,12 @@ export class AppComponent implements OnInit {
           field: 'symbol',
           header: 'Symbol',
           sortable: true,
-          filterOptions: {
-            type: 'select',
-            options: () => Array.from(new Set<string>(this.clientData?.map(e => e.symbol))).sort(),
-            multiple: true,
-          }
         },
         {
           type: 'text',
           field: 'discoveredBy',
           header: 'Discovered By',
           sortable: true,
-          filterOptions: {
-            type: 'text',
-            placeholder: 'Example: Davy or Breiner',
-          }
         },
         {
           type: 'text',
@@ -92,11 +79,6 @@ export class AppComponent implements OnInit {
           field: 'career',
           header: 'Career',
           sortable: true,
-          filterOptions: {
-            type: 'select',
-            options: () => Array.from(new Set<string>(this.clientData?.map(e => e.career))).sort(),
-            multiple: true,
-          }
         },
         {
           type: 'checkbox',
@@ -105,11 +87,6 @@ export class AppComponent implements OnInit {
           checked(row) {
             return row.online;
           },
-          filterOptions: {
-            type: 'select',
-            options: () => Array.from(new Set<boolean>(this.clientData?.map(e => e.online))).sort(),
-            multiple: true,
-          },
           align: 'center',
         },
         {
@@ -117,9 +94,6 @@ export class AppComponent implements OnInit {
           field: 'dob',
           header: 'Date of Birth',
           sortable: true,
-          filterOptions: {
-            type: 'dateRange',
-          }
         },
         {
           type: 'checkbox',
@@ -128,11 +102,6 @@ export class AppComponent implements OnInit {
           checked(row) {
             return row.married;
           },
-          filterOptions: {
-            type: 'select',
-            options: () => Array.from(new Set<boolean>(this.clientData?.map(e => e.married))).sort(),
-            multiple: true,
-          },
           align: 'center',
         },
         {
@@ -140,11 +109,6 @@ export class AppComponent implements OnInit {
           field: 'company',
           header: 'Company',
           sortable: true,
-          filterOptions: {
-            type: 'select',
-            options: () => Array.from(new Set<string>(this.clientData?.map(e => e.company))).sort(),
-            multiple: true,
-          }
         },
       ],
       stickyHeaders: true,
@@ -284,10 +248,6 @@ export class AppComponent implements OnInit {
           field: path,
           header: this._getFlattenedHeader(path),
           sortable: false,
-          filterOptions: {
-            type: 'select',
-            options: () => Array.from(new Set<boolean>(this.clientData?.map(e => this.pvp.transform(e, path)).filter((val): val is boolean => val !== undefined))).sort(),
-          },
           align: 'center',
           visible: true,
           checked: (row: any) => this.pvp.transform<typeof row, boolean>(row, path) ?? false,
@@ -298,9 +258,6 @@ export class AppComponent implements OnInit {
         field: path,
         header: this._getFlattenedHeader(path),
         sortable: true,
-        filterOptions: {
-          type: 'text',
-        },
         visible: true,
       };
     };
@@ -355,18 +312,16 @@ export class AppComponent implements OnInit {
   }
 
   protected tableDataRequestClient(): void {
-    let filteredData = [...this.clientData];
-    const filters = this.clientTable.getFilters();
+    const filteredData = [...this.clientData];
     const sort = this.clientTable.getSort();
 
     // Store filtering and sorting options.
-    const globalFilter = filters?.globalFilter;
-    const columnFilters = filters?.columnFilters;
+    // const globalFilter = '';
     const sortBy = sort?.active;
     const sortDirection = sort?.direction;
 
     // Apply global filter, if provided
-    if (globalFilter) {
+    /* if (globalFilter) {
       const searchTerm = globalFilter.toLowerCase();
       filteredData = filteredData.filter((item) =>
         Object.values(item).some((value) =>
@@ -375,44 +330,7 @@ export class AppComponent implements OnInit {
           value.toString().toLowerCase().includes(searchTerm)
         )
       );
-    }
-
-    // Apply filters, if provided
-    if (columnFilters) {
-      Object.keys(columnFilters).forEach((key) => {
-        const filterValue = columnFilters[key];
-        filteredData = filteredData.filter((item) => {
-          // Get nested value
-          const itemValue = this.pvp.transform(item, key);
-
-          // Handle range filter (e.g., "dob")
-          if (filterValue?.start || filterValue?.end) {
-            const { start, end } = filterValue;
-            const itemDate = new Date(itemValue as string).getTime();
-            return (
-              // Check if itemDate is >= start (if start exists)
-              (!start || itemDate >= start) &&
-              // Check if itemDate is <= end (if end exists)
-              (!end || itemDate <= end)
-            );
-          }
-
-          // Handle multiple values filtering (e.g., "name": ["Aluminum", "Beryllium"])
-          if (Array.isArray(filterValue)) {
-            return filterValue.includes(itemValue);
-          }
-
-          // Handle string matching (case-insensitive)
-          if (typeof itemValue === 'string') {
-            return itemValue.toLowerCase().includes(String(filterValue).toLowerCase());
-          }
-
-          // Handle direct equality checks for booleans and numbers
-          const filterPred = this.tableConfig.columnsConfig.columns.find(c => c.field === key)?.filterOptions?.filterPredicate;
-          return filterPred ? filterPred(item, filterValue) : itemValue === filterValue;
-        });
-      });
-    }
+    } */
 
     // Sort if sortBy is provided
     if (sortBy) {
@@ -457,17 +375,16 @@ export class AppComponent implements OnInit {
     this.loading = true;
     // Reset if paginator knows the data limit.
     this.serverPaginator.totalItemsKnown = false;
-    const filters = this.serverTable.getFilters();
+    // const filters = this.serverTable.getFilters();
     const sort = this.serverTable.getSort();
 
     // Store filtering and sorting options.
-    const globalFilter = filters?.globalFilter;
-    const columnFilters = filters?.columnFilters;
+    const globalFilter = '';
     const sortBy = sort?.active;
     const sortDirection = sort?.direction;
 
     setTimeout(() => {
-      this.serverData$ = this.mockService.fetchData(this.sPageIndex, this.sPageSize, sortBy, sortDirection, globalFilter, columnFilters).pipe(
+      this.serverData$ = this.mockService.fetchData(this.sPageIndex, this.sPageSize, sortBy, sortDirection, globalFilter).pipe(
         catchError(() => {
           return of([]); // Return an empty array in case of error
         }),

--- a/sp1-custom-table/src/app/app.component.ts
+++ b/sp1-custom-table/src/app/app.component.ts
@@ -197,7 +197,9 @@ export class AppComponent implements OnInit {
 
   // Client filter var.
   clientFilter = '';
+
   // Client sort var.
+  clientSort = { active: '', direction: '' };
 
   // Server paging vars.
   sPageIndex = 0;
@@ -317,12 +319,11 @@ export class AppComponent implements OnInit {
 
   tableDataRequestClient(): void {
     let filteredData = [...this.clientData];
-    const sort = this.clientTable.getSort();
 
     // Store filtering and sorting options.
     const globalFilter = this.clientFilter;
-    const sortBy = sort?.active;
-    const sortDirection = sort?.direction;
+    const sortBy = this.clientSort.active;
+    const sortDirection = this.clientSort.direction;
 
     // Apply global filter, if provided
     if (globalFilter) {
@@ -380,7 +381,7 @@ export class AppComponent implements OnInit {
     // Reset if paginator knows the data limit.
     this.serverPaginator.totalItemsKnown = false;
     // const filters = this.serverTable.getFilters();
-    const sort = this.serverTable.getSort();
+    const sort = this.serverTable as any; // LOL Please don't do this in production code.
 
     // Store filtering and sorting options.
     const globalFilter = '';
@@ -419,8 +420,13 @@ export class AppComponent implements OnInit {
     clearInterval(this._refreshIntervalId);
   }
 
-  clientFilterChanged(filterStr: string): void {
-    this.clientFilter = filterStr;
+  clientFilterChanged(updatedFilter: string): void {
+    this.clientFilter = updatedFilter;
+    this.tableDataRequestClient();
+  }
+
+  clientSortChanged(updatedSort: { active: string; direction: string }): void {
+    this.clientSort = updatedSort;
     this.tableDataRequestClient();
   }
 

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.html
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.html
@@ -91,7 +91,7 @@
           <table mat-table [dataSource]="dataSource" matSort
             [matSortActive]="tableConfig.sortOptions?.initialSort?.active ?? ''"
             [matSortDirection]="tableConfig.sortOptions?.initialSort?.direction ?? ''"
-            (matSortChange)="sortChange($event)">
+            (matSortChange)="onSortChange($event)">
       
             <!--- Note that these columns can be defined in any order.
                   The actual rendered columns are set as a property on the row definition" -->

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.html
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.html
@@ -12,7 +12,7 @@
       
         <div class="table-filter-container">
           <div class="table-buttons">
-            @if (tableConfig.filterOptions || columnFiltersPresent) {
+            @if (tableConfig.filterOptions) {
               <button class="smaller-padding"
                 mat-flat-button
                 color="accent"
@@ -20,17 +20,6 @@
                 [attr.aria-label]="resetFiltersTooltip"
                 (click)="resetFilters()">
                 Reset Filters
-              </button>
-            }
-
-            @if (columnFilters) {
-              <button class="smaller-padding"
-                mat-flat-button
-                color="accent"
-                [matTooltip]="toggleFiltersTooltip"
-                [attr.aria-label]="toggleFiltersTooltip"
-                (click)="toggleColumnFilters()">
-                {{ showColumnFilters ? 'Hide' : 'Show' }} Filters
               </button>
             }
 
@@ -97,44 +86,6 @@
             </div>
           }
         </div>
-
-        @if (columnFiltersPresent) {
-          <div class="column-filters-container"
-            [class.hide-columns]="!showColumnFilters">
-            @for (column of displayedFilters; track column.field; let i = $index) {
-              @if (column.filterOptions && (column.visible ?? true)) {
-                <div class="column-filter-container">
-                  @switch (column.filterOptions.type) {
-                    @case ('text') {
-                      <ng-container
-                        *ngTemplateOutlet="textFilter;
-                          context: { $implicit: column, filters: columnFilters }">
-                      </ng-container>
-                    }
-                    @case ('select') {
-                      <ng-container
-                        *ngTemplateOutlet="selectFilter;
-                          context: { $implicit: column, filters: columnFilters }">
-                      </ng-container>
-                    }
-                    @case ('singleDate') {
-                      <ng-container
-                        *ngTemplateOutlet="singleDateFilter;
-                          context: { $implicit: column, filters: columnFilters }">
-                      </ng-container>
-                    }
-                    @case ('dateRange') {
-                      <ng-container
-                        *ngTemplateOutlet="dateRangeFilter;
-                          context: { $implicit: column, filters: columnFilters }">
-                      </ng-container>
-                    }
-                  }
-                </div>
-              }
-            }
-          </div>
-        }
       
         <div class="table-container">
           <table mat-table [dataSource]="dataSource" matSort
@@ -212,7 +163,7 @@
             }
       
             <!-- Headers -->
-            <tr class="non-filter-header" mat-header-row *matHeaderRowDef="displayColumns; sticky: tableConfig.columnsConfig.stickyHeaders"></tr>
+            <tr mat-header-row *matHeaderRowDef="displayColumns; sticky: tableConfig.columnsConfig.stickyHeaders"></tr>
 
             <!-- Data rows -->
             <tr mat-row *matRowDef="let row; columns: displayColumns"
@@ -239,114 +190,4 @@
 <!-- Checkbox -->
 <ng-template #checkboxTemplate let-checked="checked" let-row="row">
   <mat-checkbox [color]="'primary'" [checked]="checked(row)" disabled></mat-checkbox>
-</ng-template>
-
-<!-- Defined Column Filter Templates -->
-<!-- Text -->
-<ng-template #textFilter let-column let-filters="filters">
-  <app-search-bar
-    [label]="column.filterOptions.label ?? 'Filter by ' + column.header"
-    [placeholder]="column.filterOptions.placeholder ?? ''"
-    [instantSearch]="column.filterOptions.instantSearch ?? false"
-    [showSearchIcon]="false"
-    [(value)]="filters[column.field]"
-    (valueChange)="applyFilters()">
-  </app-search-bar>
-</ng-template>
-<!-- Select -->
-<ng-template #selectFilter let-column let-filters="filters">
-  <mat-form-field appearance="outline">
-    <mat-label> {{ column.filterOptions.label ?? 'Filter by ' + column.header }} </mat-label>
-    <mat-select
-      [(ngModel)]="filters[column.field]"
-      (selectionChange)="applyFilters()"
-      [multiple]="column.filterOptions.multiple">
-      @if (!column.filterOptions.multiple) {
-        <mat-option [value]=""> -- </mat-option>
-      }
-      @for (option of column.filterOptions.options(); track option) {
-        <mat-option [value]="option"> {{ option }} </mat-option>
-      }
-    </mat-select>
-  </mat-form-field>
-</ng-template>
-<!-- Single Date -->
-<ng-template #singleDateFilter let-column let-filters="filters">
-  <form [formGroup]="single">
-    <mat-form-field class="date-column-filter" appearance="outline">
-      <mat-label> {{ column.filterOptions.label ?? 'Filter by ' + column.header }} </mat-label>
-      <input matInput
-        [matDatepicker]="picker"
-        formControlName="date"
-        [placeholder]="column.filterOptions.placeholder ?? 'Select date'"
-        (dateInput)="
-          filters[column.field] = $event.value;
-          applyFilters()
-        "/>
-  
-      @if (filters[column.field]) {
-        <button mat-icon-button matSuffix
-          (click)="
-            filters[column.field] = '';
-            single.reset();
-            applyFilters()
-          "
-          [attr.aria-label]="'Clear {{column.header}} filter'">
-          <mat-icon>close</mat-icon>
-        </button>
-      }
-  
-      <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
-      <mat-datepicker #picker></mat-datepicker>
-  
-      @if (single.invalid) {
-        <mat-error>Invalid date</mat-error>
-      }
-    </mat-form-field>
-  </form>
-</ng-template>
-<!-- Date range -->
-<ng-template #dateRangeFilter let-column let-filters="filters">
-  <mat-form-field appearance="outline">
-    <mat-label> {{ column.filterOptions.label ?? 'Filter by ' + column.header }} </mat-label>
-    <mat-date-range-input [formGroup]="range" [rangePicker]="picker">
-      <input matStartDate
-        formControlName="start"
-        placeholder="Start date"
-        (dateInput)="
-          filters[column.field] = range.value;
-          applyFilters()
-        ">
-      <input matEndDate
-        formControlName="end"
-        placeholder="End date"
-        (dateInput)="
-          filters[column.field] = range.value;
-          applyFilters()
-        ">
-    </mat-date-range-input>
-
-    @if (filters[column.field]) {
-      <button mat-icon-button matSuffix
-        (click)="
-          filters[column.field] = '';
-          range.reset();
-          applyFilters()
-        "
-        [attr.aria-label]="'Clear {{column.header}} filter'">
-        <mat-icon>close</mat-icon>
-      </button>
-    }
-
-    <mat-hint>MM/DD/YYYY – MM/DD/YYYY</mat-hint>
-    <mat-datepicker-toggle matIconSuffix [for]="picker"></mat-datepicker-toggle>
-    <mat-date-range-picker #picker></mat-date-range-picker>
-  
-    @if (range.controls.start.hasError('matStartDateInvalid')) {
-      <mat-error>Invalid start date</mat-error>
-    }
-    @if (range.controls.end.hasError('matEndDateInvalid')) {
-      <mat-error>Invalid end date</mat-error>
-    }
-  </mat-form-field>
 </ng-template>

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.html
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.html
@@ -54,7 +54,7 @@
                 [label]="tableConfig.filterOptions.label ?? ''"
                 [placeholder]="tableConfig.filterOptions.placeholder ?? ''"
                 [animateWidth]="true"
-                (valueChange)="applyFilter($event)">
+                (valueChange)="onFilterChange($event)">
               </app-search-bar>
             </div>
           }

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.html
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.html
@@ -11,18 +11,20 @@
           [style.z-index]="loadingTail ? 110 : -1"></div>
       
         <div class="table-filter-container">
-          <div class="table-buttons">
-            @if (tableConfig.filterOptions) {
-              <button class="smaller-padding"
-                mat-flat-button
-                color="accent"
-                [matTooltip]="resetFiltersTooltip"
-                [attr.aria-label]="resetFiltersTooltip"
-                (click)="resetFilters()">
-                Reset Filters
-              </button>
-            }
+          <!-- Table search bar -->
+          @if (tableConfig.filterOptions) {
+            <div class="table-search-bar">
+              <app-search-bar #searchBar
+                [label]="tableConfig.filterOptions.label ?? ''"
+                [placeholder]="tableConfig.filterOptions.placeholder ?? ''"
+                (valueChange)="onFilterChange($event)">
+              </app-search-bar>
+            </div>
+          }
 
+          <app-span-filler></app-span-filler>
+
+          <div class="table-buttons">
             @if (selectedRows.length > 0) {
               <button mat-icon-button
                 color="accent"
@@ -44,20 +46,6 @@
               </mat-menu>
             }
           </div>
-
-          <app-span-filler></app-span-filler>
-
-          <!-- Table search bar -->
-          @if (tableConfig.filterOptions) {
-            <div class="table-search-bar">
-              <app-search-bar #searchBar
-                [label]="tableConfig.filterOptions.label ?? ''"
-                [placeholder]="tableConfig.filterOptions.placeholder ?? ''"
-                [animateWidth]="true"
-                (valueChange)="onFilterChange($event)">
-              </app-search-bar>
-            </div>
-          }
           
           <!-- Table menu -->
           @if (tableConfig.autoRefresh) {

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.scss
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.scss
@@ -28,26 +28,6 @@
   }
 }
 
-.column-filters-container {
-  display: flex;
-  flex-flow: row wrap;
-  padding-top: .25em;
-  column-gap: 0.5em;
-  max-height: 500px;
-  opacity: 1;
-  transition: max-height 0.5s ease, opacity 650ms ease;
-  overflow: hidden;
-
-  &.hide-columns {
-    max-height: 0;
-    opacity: 0;
-  }
-
-  .column-filter-container {
-    min-width: 300px;
-  }
-}
-
 .table-container {
   margin: 0 auto;
   overflow: auto;
@@ -69,9 +49,7 @@ table {
 }
 
 .mat-mdc-header-row {
-  &.non-filter-header {
-    height: 26px;
-  }
+  height: 26px;
 }
 
 .mat-mdc-row {
@@ -93,10 +71,6 @@ table {
 }
 
 .mdc-button {
-  &.smaller-padding {
-    padding: 0 16px;
-  }
-
   &.template-cell-button {
     border-radius: 6px !important;
   }

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.ts
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.ts
@@ -68,13 +68,18 @@ export class CustomTableComponent implements OnChanges {
    */
   @Output() getData = new EventEmitter<void>();
 
+  /**
+   * Event emitted when search bar value changes.
+   * @type {EventEmitter<string>}
+   */
+  @Output() filterChange = new EventEmitter<string>();
+
   @ViewChild('searchBar') searchBar!: SearchBarComponent;
   @ViewChild('sidenav') sidenav!: MatSidenav;
   @ViewChild('sidenavContent', { read: ViewContainerRef }) sidenavContent!: ViewContainerRef;
 
   // Table data vars.
   protected dataSource = new MatTableDataSource<any>(); // MatTableDataSource instance
-  protected globalFilter!: string; // Filter string from main search box
 
   // Table column vars.
   protected displayColumns: string[] = [];
@@ -195,8 +200,8 @@ export class CustomTableComponent implements OnChanges {
    * Applies the global filter.
    * @param {string} filterString - The filter string.
    */
-  protected applyFilter(filterString: string): void {
-    this.globalFilter = filterString;
+  protected onFilterChange(filterString: string): void {
+    this.filterChange.emit(filterString);
   }
 
   /**
@@ -239,7 +244,6 @@ export class CustomTableComponent implements OnChanges {
    * Resets all filters.
    */
   protected resetFilters(): void {
-    this.globalFilter = '';
     this.searchBar.clear();
   }
 

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.ts
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.ts
@@ -74,6 +74,12 @@ export class CustomTableComponent implements OnChanges {
    */
   @Output() filterChange = new EventEmitter<string>();
 
+  /**
+   * Event emitted when sort changes.
+   * @type {EventEmitter<Sort>}
+   */
+  @Output() sortChange = new EventEmitter<Sort>();
+
   @ViewChild('searchBar') searchBar!: SearchBarComponent;
   @ViewChild('sidenav') sidenav!: MatSidenav;
   @ViewChild('sidenavContent', { read: ViewContainerRef }) sidenavContent!: ViewContainerRef;
@@ -83,7 +89,6 @@ export class CustomTableComponent implements OnChanges {
 
   // Table column vars.
   protected displayColumns: string[] = [];
-  protected currentSort!: Sort;
   protected defaultColumnConfig!: Column<any>[];
 
   // Selected rows vars.
@@ -152,12 +157,6 @@ export class CustomTableComponent implements OnChanges {
         ];
       }
 
-      // Set sort properties if available.
-      this.currentSort = {
-        active: tableConfig.sortOptions?.initialSort?.active ?? '',
-        direction: tableConfig.sortOptions?.initialSort?.direction ?? '',
-      };
-
       this.detector.detectChanges();
     }
 
@@ -166,14 +165,6 @@ export class CustomTableComponent implements OnChanges {
       this.dataSource = new MatTableDataSource(changes['tableData']?.currentValue);
       this.detector.detectChanges();
     }
-  }
-
-  /**
-   * Gets the current sort state.
-   * @returns {Sort} - The current sort state.
-   */
-  getSort(): Sort {
-    return this.currentSort;
   }
 
   /**
@@ -186,22 +177,21 @@ export class CustomTableComponent implements OnChanges {
   }
 
   /**
-   * Handles sort change event.
-   * @param {Sort} event - The sort event.
-   */
-  protected sortChange(event: Sort): void {
-    const sortDirection = event.direction ? `${event.direction}ending` : 'cleared';
-    this.announcer.announce(`Sorting by ${event.active} ${sortDirection}`);
-    this.currentSort = event;
-    this._requestNewData();
-  }
-
-  /**
-   * Applies the global filter.
+   * Emits the filter change event.
    * @param {string} filterString - The filter string.
    */
   protected onFilterChange(filterString: string): void {
     this.filterChange.emit(filterString);
+  }
+
+  /**
+   * Handles sort change event and emits teh sort change event.
+   * @param {Sort} event - The sort event.
+   */
+  protected onSortChange(event: Sort): void {
+    const sortDirection = event.direction ? `${event.direction}ending` : 'cleared';
+    this.announcer.announce(`Sorting by ${event.active} ${sortDirection}`);
+    this.sortChange.emit(event);
   }
 
   /**

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.ts
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.ts
@@ -63,12 +63,6 @@ export class CustomTableComponent implements OnChanges {
   private _loading!: boolean;
 
   /**
-   * Event emitted to request new data.
-   * @type {EventEmitter<void>}
-   */
-  @Output() getData = new EventEmitter<void>();
-
-  /**
    * Event emitted when search bar value changes.
    * @type {EventEmitter<string>}
    */
@@ -258,12 +252,5 @@ export class CustomTableComponent implements OnChanges {
     if (this.tableConfig.rowActions) {
       this.displayColumns.push('actions');
     }
-  }
-
-  /**
-   * Requests new data.
-   */
-  private _requestNewData(): void {
-    this.getData.emit();
   }
 }

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.ts
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.ts
@@ -89,7 +89,6 @@ export class CustomTableComponent implements OnChanges {
   protected selectedRows: any[] = []; // Store selected rows of table.
 
   // Tooltip vars.
-  protected resetFiltersTooltip = 'Clear all filters and search terms';
   protected multiRowActionMenuTooltip = 'Show more actions';
 
   // Magic var.
@@ -223,13 +222,6 @@ export class CustomTableComponent implements OnChanges {
     return this.dataSource._pageData(this.dataSource.data).some((row) => row.selected) &&
       !this.dataSource._pageData(this.dataSource.data).every((row) => row.selected);
   };
-
-  /**
-   * Resets all filters.
-   */
-  protected resetFilters(): void {
-    this.searchBar.clear();
-  }
 
   /**
    * Generates the display columns based on the column configuration.

--- a/sp1-custom-table/src/app/shared/components/custom-table/models/column.model.ts
+++ b/sp1-custom-table/src/app/shared/components/custom-table/models/column.model.ts
@@ -82,7 +82,7 @@ interface BaseColumn<T> {
    * @type {ColumnFilter}
    * @optional
    */
-  filterOptions?: ColumnFilter;
+  filterOptions?: ColumnFilter<T>;
   /**
    * Determine alignment of column text.
    * @type {'left' | 'center' | 'right'}

--- a/sp1-custom-table/src/app/shared/components/custom-table/models/filter.model.ts
+++ b/sp1-custom-table/src/app/shared/components/custom-table/models/filter.model.ts
@@ -1,12 +1,7 @@
 /**
- * Represents a column filter.
+ * Represents a table search bar configuration.
  */
-export type ColumnFilter = TextFilter | SelectFilter | SingleDateFilter | DateRangeFilter;
-
-/**
- * Represents a table filter configuration.
- */
-export interface TableFilter {
+export interface SearchBarConfig {
   /**
    * ID for filter input element.
    * @type {string}
@@ -36,24 +31,7 @@ export interface TableFilter {
 /**
  * Base interface for column filters.
  */
-export interface BaseColumnFilter {
-  /**
-   * Type of filter.
-   * @type {string}
-   */
-  type: string;
-  /**
-   * Label for filter input.
-   * @type {string}
-   * @optional
-   */
-  label?: string;
-  /**
-   * Placeholder text for filter input.
-   * @type {string}
-   * @optional
-   */
-  placeholder?: string;
+export interface ColumnFilter<T> {
   /**
    * Custom filter logic.
    * @param {any} data - The data to filter.
@@ -62,68 +40,5 @@ export interface BaseColumnFilter {
    * @type {function}
    * @optional
    */
-  filterPredicate?: (data: any, filter: string) => boolean;
-}
-
-/**
- * Represents a text filter configuration.
- */
-interface TextFilter extends BaseColumnFilter {
-  /**
-   * Discriminator to distinguish this as a text filter.
-   * @type {'text'}
-   */
-  type: 'text';
-  /**
-   * Determines if the filter should execute instantly.
-   * @type {boolean}
-   * @optional
-   */
-  instantSearch?: boolean;
-}
-
-/**
- * Represents a select filter configuration.
- * @template T - The type of the options.
- */
-interface SelectFilter<T = any> extends BaseColumnFilter {
-  /**
-   * Discriminator to distinguish this as a select filter.
-   * @type {'select'}
-   */
-  type: 'select';
-  /**
-   * Array of options for the select filter.
-   * @returns {T[]} - The options for the select filter.
-   * @type {function}
-   */
-  options: () => T[];
-  /**
-   * Whether the select filter allows multiple selections.
-   * @type {boolean}
-   * @optional
-   */
-  multiple?: boolean;
-}
-
-/**
- * Represents a single date filter configuration.
- */
-interface SingleDateFilter extends BaseColumnFilter {
-  /**
-   * Discriminator to distinguish this as a single date filter.
-   * @type {'singleDate'}
-   */
-  type: 'singleDate';
-}
-
-/**
- * Represents a date range filter configuration.
- */
-interface DateRangeFilter extends BaseColumnFilter {
-  /**
-   * Discriminator to distinguish this as a date range filter.
-   * @type {'dateRange'}
-   */
-  type: 'dateRange';
+  filterPredicate?: (data: T, filter: string) => boolean;
 }

--- a/sp1-custom-table/src/app/shared/components/custom-table/models/table.model.ts
+++ b/sp1-custom-table/src/app/shared/components/custom-table/models/table.model.ts
@@ -1,4 +1,4 @@
-import { TableFilter } from './filter.model';
+import { SearchBarConfig } from './filter.model';
 import { ColumnsConfig } from './column.model';
 import { RowActionsConfig, TableAction, SelectedRowAction } from './actions.model';
 import { SortConfig } from './sort.model';
@@ -120,9 +120,9 @@ export interface TableConfig<T> {
    */
   rowActions?: RowActionsConfig;
   /**
-   * Configuration for table filter
-   * @type {TableFilter}
+   * Configuration for table search bar filter
+   * @type {SearchBarConfig}
    * @optional
    */
-  filterOptions?: TableFilter;
+  filterOptions?: SearchBarConfig;
 }

--- a/sp1-custom-table/src/app/shared/components/search-bar/search-bar.component.html
+++ b/sp1-custom-table/src/app/shared/components/search-bar/search-bar.component.html
@@ -1,40 +1,31 @@
-<div class="search-bar-container"
-  [class.animate-width]="animateWidth">
-  <span [class.disabled-wrapper]="disabled">
-    <mat-form-field class="search-form-field"
-      [class.animate-width]="animateWidth"
-      [appearance]="appearance"
-      [subscriptSizing]="subscriptSizing"
-      [color]="color">
-  
-      <mat-label [class.animate-width]="animateWidth">
-        {{ label }}
-      </mat-label>
-  
-      <input class="search-input"
-        type="text"
-        matInput
-        [formControl]="searchControl"
-        [placeholder]="placeholder"
-        [required]="required"
-        (focus)="onFocusIn()"
-        (blur)="onBlur()"/>
-  
-      @if (showSearchIcon) {
-        <mat-icon matPrefix>search</mat-icon>
-      }
-  
-      @if (showClearButton()) {
-        <button class="clear-button"
-          [class.animate-width]="animateWidth"
-          mat-icon-button
-          matSuffix
-          [attr.aria-label]="clearAriaLabel"
-          [disabled]="empty()"
-          (click)="clear()">
-          <mat-icon>close</mat-icon>
-        </button>
-      }
-    </mat-form-field>
-  </span>
-</div>
+<span [class.disabled-wrapper]="disabled">
+  <mat-form-field
+    [appearance]="appearance"
+    [subscriptSizing]="subscriptSizing"
+    [color]="color">
+
+    <mat-label [@floatLabel]="floatState">{{ label }}</mat-label>
+
+    <input class="search-input"
+      type="text"
+      matInput
+      [formControl]="searchControl"
+      [placeholder]="placeholder"
+      [required]="required"
+      (focus)="onFocusIn()"
+      (blur)="onBlur()"/>
+
+    @if (showSearchIcon) {
+      <mat-icon matPrefix>search</mat-icon>
+    }
+
+    <button class="clear-button"
+      mat-icon-button
+      matSuffix
+      [attr.aria-label]="clearAriaLabel"
+      [disabled]="empty()"
+      (click)="clear()">
+      <mat-icon>close</mat-icon>
+    </button>
+  </mat-form-field>
+</span>

--- a/sp1-custom-table/src/app/shared/components/search-bar/search-bar.component.scss
+++ b/sp1-custom-table/src/app/shared/components/search-bar/search-bar.component.scss
@@ -1,53 +1,7 @@
-.search-bar-container {
-  &.animate-width {
-    // https://stackoverflow.com/questions/42005716/animated-search-form-expanding-to-the-left
-    text-align: right;
-  }
-}
-
 mat-form-field {
   width: 100%;
 }
 
-.search-form-field {
-  &.animate-width {
-    width: 65px;
-    transition: width 550ms ease-out;
-  }
-}
-
 ::placeholder {
   font-style: italic;
-
-  &.animate-width {
-    opacity: 0;
-    transition: opacity 600ms;
-  }
-}
-
-mat-label {
-  &.animate-width {
-    opacity: 0;
-    transition: opacity 650ms;
-  }
-}
-
-.clear-button {
-  &.animate-width {
-    opacity: 0;
-    transition: opacity 600ms;
-  }
-}
-
-:host.has-focus {
-
-  .search-form-field {
-    width: 100%;
-  }
-
-  mat-label,
-  ::placeholder,
-  .clear-button {
-    opacity: 1;
-  }
 }

--- a/sp1-custom-table/src/app/shared/components/search-bar/search-bar.component.scss
+++ b/sp1-custom-table/src/app/shared/components/search-bar/search-bar.component.scss
@@ -11,8 +11,8 @@ mat-form-field {
 
 .search-form-field {
   &.animate-width {
-    width: 45px;
-    transition: width 400ms;
+    width: 65px;
+    transition: width 550ms ease-out;
   }
 }
 
@@ -21,21 +21,21 @@ mat-form-field {
 
   &.animate-width {
     opacity: 0;
-    transition: opacity 400ms;
+    transition: opacity 600ms;
   }
 }
 
 mat-label {
   &.animate-width {
     opacity: 0;
-    transition: opacity 400ms;
+    transition: opacity 650ms;
   }
 }
 
 .clear-button {
   &.animate-width {
     opacity: 0;
-    transition: opacity 400ms;
+    transition: opacity 600ms;
   }
 }
 


### PR DESCRIPTION
- Removed column generated filters
- The SearchBar in CustomTable UI has its event simply passed through to parent of CustomTable
- Filter and sort state changes are not longer contained within CustomTable but passed along to parent via event emitters
- SearchBar expansion animation removed, added fun label animation (I still wanted an animation dang it!)
- Because of the leaning out of CustomTable, some function now had no purpose:
    - resetFilters
    - applyFilters
    - applyFilter
    - getFilters
    - getSort
    - _isEmpty
    - _sanitizeFilters
    - toggleColumnFilters
    - _requestNewData

I have learned that the CustomTable component was too bulky and didn't separate concern well. The pull request leaned it out quite a bit!