### PR TITLE
79 add ng content blocks to allow extra filter options

### DIFF
--- a/sp1-custom-table/src/app/app.component.html
+++ b/sp1-custom-table/src/app/app.component.html
@@ -17,6 +17,15 @@
         [pageSize]="cPageSize"
         (filterChange)="clientFilterChanged($event)"
         (sortChange)="clientSortChanged($event)">
+        <div>
+          <mat-chip-listbox aria-label="select a filter"
+            (change)="onChipChange($event.value)"
+            multiple>
+            <mat-chip-option color="primary" [value]="{ field: 'name', value:'Carbon' }"> Carbon </mat-chip-option>
+            <mat-chip-option color="primary" [value]="{ field: 'online', value:true }"> Online Graduate </mat-chip-option>
+            <mat-chip-option color="primary" [value]="{ field: 'career', value:'Paleontologist' }"> Paleontologist </mat-chip-option>
+          </mat-chip-listbox>
+        </div>
       </app-custom-table>
   
       <mat-divider></mat-divider>

--- a/sp1-custom-table/src/app/app.component.html
+++ b/sp1-custom-table/src/app/app.component.html
@@ -18,6 +18,21 @@
         (filterChange)="clientFilterChanged($event)"
         (sortChange)="clientSortChanged($event)">
         <div>
+          <mat-form-field appearance="outline">
+            <mat-label>Filter by Symbol</mat-label>
+            <mat-select #symbolSelect
+              [(ngModel)]="clientColumnFilters['symbol']"
+              (selectionChange)="onSelectChange($event.value)">
+              @if (!symbolSelect.multiple) {
+                <mat-option [value]=""> -- </mat-option>
+              }
+              @for (symbol of clientSymbols; track symbol) {
+                <mat-option [value]="symbol">{{ symbol }}</mat-option>
+              }
+            </mat-select>
+          </mat-form-field>
+        </div>
+        <div>
           <mat-chip-listbox aria-label="select a filter"
             (change)="onChipChange($event.value)"
             multiple>

--- a/sp1-custom-table/src/app/app.component.ts
+++ b/sp1-custom-table/src/app/app.component.ts
@@ -13,6 +13,9 @@ import { PathValuePipe } from './shared/pipes/path-value.pipe';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { SpanFillerComponent } from './shared/components/span-filler/span-filler.component';
 import { MatChipsModule } from '@angular/material/chips';
+import { MatSelectChange, MatSelectModule } from '@angular/material/select';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { FormsModule } from '@angular/forms';
 
 const AFREFRESH = 2000;
 
@@ -20,7 +23,7 @@ const AFREFRESH = 2000;
   selector: 'app-root',
   standalone: true,
   imports: [CustomTableComponent, ClientPaginatorComponent, ServerPaginatorComponent, AsyncPipe, MatDividerModule, MatSlideToggleModule, SpanFillerComponent,
-    MatChipsModule
+    MatChipsModule, MatSelectModule, MatFormFieldModule, FormsModule
   ],
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss',
@@ -166,7 +169,7 @@ export class AppComponent implements OnInit {
   clientConfig: TableConfig<MockModel> = {
     ...this.tableConfig,
     autoRefresh: {
-      enabled: true,
+      enabled: false,
       onChange: (enabled) => {
         this.toggleAutoRefresh(enabled);
       },
@@ -232,6 +235,7 @@ export class AppComponent implements OnInit {
   // Client filter vars.
   clientSearchBarText = '';
   clientColumnFilters: Record<string, unknown> = {};
+  clientSymbols: string[] = [];
   // Client sort var.
   clientSort = { active: '', direction: '' };
 
@@ -277,9 +281,6 @@ export class AppComponent implements OnInit {
   ngOnInit(): void {
     // Client side pagination start.
     this.loadData();
-
-    // Start auto refresh on client table.
-    // this.startAF();
   }
 
   loadData(): void {
@@ -320,6 +321,7 @@ export class AppComponent implements OnInit {
     );
 
     this.filteredData = [...this.clientData];
+    this.clientSymbols = Array.from(new Set(this.clientData.map((data: MockModel) => data.symbol))).sort();
     this.detector.detectChanges();
   }
 
@@ -507,6 +509,14 @@ export class AppComponent implements OnInit {
   onChipChange(changes: { field: string; value: string }[]): void {
     this.clientColumnFilters = {};
     changes.forEach(change => this.clientColumnFilters[change.field] = change.value);
+    this.tableDataRequestClient();
+  }
+
+  onSelectChange(value: MatSelectChange): void {
+    this.clientColumnFilters['symbol'] = value;
+    if (!this.clientColumnFilters['symbol']) {
+      delete this.clientColumnFilters['symbol'];
+    }
     this.tableDataRequestClient();
   }
 

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.html
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.html
@@ -74,6 +74,10 @@
             </div>
           }
         </div>
+
+        <ng-content />
+
+        <ng-content select="quick-filter-chips" />
       
         <div class="table-container">
           <table mat-table [dataSource]="tableData" matSort

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.html
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.html
@@ -75,9 +75,8 @@
           }
         </div>
 
+        <!-- Slot for anything to enhance table visuals like column filter and/or mat-chip quick filter options. -->
         <ng-content />
-
-        <ng-content select="quick-filter-chips" />
       
         <div class="table-container">
           <table mat-table [dataSource]="tableData" matSort

--- a/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.html
+++ b/sp1-custom-table/src/app/shared/components/custom-table/custom-table.component.html
@@ -125,7 +125,7 @@
                       <ng-container *ngTemplateOutlet="slideToggleTemplate; context: {checked: column.checked, row: row}"></ng-container>
                     }
                     @default {
-                      {{ column.valueGetter?.(row) ?? row | pathValue: column.field }}
+                      {{ column.valueGetter ? column.valueGetter(row) : (row | pathValue: column.field) }}
                     }
                   }
                 </td>


### PR DESCRIPTION
Content projection block for added table visuals:
    - added examples of mat-chip (quick/smart filter) or mat-select (column-level filter)
-Fixed bug of column valueGetter method not being called