### PR TITLE
89 keep menus open focus order

### DIFF
--- a/sp1-custom-table/src/app/shared/components/table/table.component.html
+++ b/sp1-custom-table/src/app/shared/components/table/table.component.html
@@ -1,14 +1,19 @@
 <mat-sidenav-container>
-  <mat-sidenav #sidenav mode="over" position="end">
+  <mat-sidenav #sidenav
+    mode="over"
+    position="end">
     <ng-container #sidenavContent></ng-container>
   </mat-sidenav>
   <mat-sidenav-content>
     @if (tableConfig) {
       <div [style.position]="'relative'">
-        <div class="spinner-div" appGeneralSpinner
-          [spinnerBusy]="loading" [spinnerColor]="'accent'"
+        <div class="spinner-div"
+          appGeneralSpinner
+          [spinnerBusy]="loading"
+          [spinnerColor]="'accent'"
           [style.background]="loading ? 'var(--spinner-background)' : 'none'"
-          [style.z-index]="loadingTail ? 110 : -1"></div>
+          [style.z-index]="loadingTail ? 110 : -1">
+        </div>
       
         <div class="table-filter-container">
           <!-- Table search bar -->
@@ -61,7 +66,9 @@
           }
           @if ((tableConfig.tableActions?.length ?? 0) > 0) {
             <div class="table-menu">
-              <button mat-icon-button [color]="'accent'" [matMenuTriggerFor]="tableMenu">
+              <button mat-icon-button
+                [color]="'accent'"
+                [matMenuTriggerFor]="tableMenu">
                 <mat-icon>settings</mat-icon>
               </button>
               <mat-menu #tableMenu="matMenu">
@@ -79,7 +86,9 @@
         <ng-content />
       
         <div class="table-container">
-          <table mat-table [dataSource]="tableData" matSort
+          <table mat-table
+            [dataSource]="tableData"
+            matSort
             [matSortActive]="tableConfig.sortOptions?.initialSort?.active ?? ''"
             [matSortDirection]="tableConfig.sortOptions?.initialSort?.direction ?? ''"
             (matSortChange)="onSortChange($event)">
@@ -88,10 +97,17 @@
             @if (tableConfig.multiRowSelection) {
               <ng-container matColumnDef="select">
                 <th mat-header-cell *matHeaderCellDef>
-                  <mat-checkbox [checked]="allSelected()" [indeterminate]="someSelected()" (change)="toggleAllSelection($event.checked)"></mat-checkbox>
+                  <mat-checkbox
+                    [checked]="allSelected()"
+                    [indeterminate]="someSelected()"
+                    (change)="toggleAllSelection($event.checked)">
+                  </mat-checkbox>
                 </th>
                 <td mat-cell *matCellDef="let row">
-                  <mat-checkbox [checked]="isSelected(row)" (change)="toggleRowSelection($event.checked, row)"></mat-checkbox>
+                  <mat-checkbox
+                    [checked]="isSelected(row)"
+                    (change)="toggleRowSelection($event.checked, row)">
+                  </mat-checkbox>
                 </td>
               </ng-container>
             }
@@ -107,12 +123,15 @@
             <!-- Columns generated from table configuration. -->
             @for (column of tableConfig.columnsConfig.columns; track column.field) {
               <ng-container matColumnDef="{{ column.field }}">
-                <th mat-header-cell *matHeaderCellDef mat-sort-header
-                  sortActionDescription="Sort by {{column.field}}" [disabled]="!column.sortable"
+                <th mat-header-cell *matHeaderCellDef
+                  mat-sort-header
+                  sortActionDescription="Sort by {{column.field}}"
+                  [disabled]="!column.sortable"
                   [style.text-align]="column.align">
                   {{ column.header }}
                 </th>
-                <td mat-cell *matCellDef="let row" [ngClass]="column.cellClass?.(row) ?? ''"
+                <td mat-cell *matCellDef="let row"
+                  [ngClass]="column.cellClass?.(row) ?? ''"
                   [style.text-align]="column.align ?? 'left'">
                   @switch (column.type) {
                     @case ('button') {
@@ -137,12 +156,17 @@
               <ng-container matColumnDef="actions" [stickyEnd]="tableConfig.rowActions.stickyActions">
                 <th mat-header-cell *matHeaderCellDef> Actions </th>
                 <td mat-cell *matCellDef="let row">
-                  <button mat-icon-button [color]="'accent'" [matMenuTriggerFor]="actionMenu">
+                  <button mat-icon-button
+                    [color]="'accent'"
+                    [matMenuTriggerFor]="actionMenu">
                     <mat-icon>more_vert</mat-icon>
                   </button>
                   <mat-menu #actionMenu="matMenu">
                     @for (action of tableConfig.rowActions.actions; track action) {
-                      <button mat-menu-item [attr.aria-label]="action.description" [disabled]="action.disabled?.(row)" (click)="action.action(row)">
+                      <button mat-menu-item
+                        [attr.aria-label]="action.description"
+                        [disabled]="action.disabled?.(row)"
+                        (click)="action.action(row)">
                         <span> {{ action.label }}</span>
                       </button>
                     }
@@ -178,9 +202,17 @@
 </ng-template>
 <!-- Checkbox -->
 <ng-template #checkboxTemplate let-checked="checked" let-row="row">
-  <mat-checkbox [color]="'primary'" [checked]="checked(row)" disabled></mat-checkbox>
+  <mat-checkbox
+    [color]="'primary'"
+    [checked]="checked(row)"
+    disabled>
+  </mat-checkbox>
 </ng-template>
 <!-- Slide toggle -->
 <ng-template #slideToggleTemplate let-checked="checked" let-row="row">
-  <mat-slide-toggle [color]="'primary'" [checked]="checked(row)" disabled></mat-slide-toggle>
+  <mat-slide-toggle
+    [color]="'primary'"
+    [checked]="checked(row)"
+    disabled>
+  </mat-slide-toggle>
 </ng-template>

--- a/sp1-custom-table/src/app/shared/components/table/table.component.html
+++ b/sp1-custom-table/src/app/shared/components/table/table.component.html
@@ -46,7 +46,7 @@
                   <button mat-menu-item
                     [attr.aria-label]="action.description"
                     [disabled]="action.disabled?.(getSelectedRows())"
-                    (click)="action.action(getSelectedRows())">
+                    (click)="$event.stopPropagation(); action.action(getSelectedRows())">
                     {{ action.label }}
                   </button>
                 }
@@ -73,7 +73,10 @@
               </button>
               <mat-menu #tableMenu="matMenu">
                 @for (action of tableConfig.tableActions; track action) {
-                  <button mat-menu-item [attr.aria-label]="action.description" [disabled]="action.disabled?.()" (click)="action.action()">
+                  <button mat-menu-item
+                    [attr.aria-label]="action.description"
+                    [disabled]="action.disabled?.()"
+                    (click)="$event.stopPropagation(); action.action()">
                     {{ action.label }}
                   </button>
                 }
@@ -166,7 +169,7 @@
                       <button mat-menu-item
                         [attr.aria-label]="action.description"
                         [disabled]="action.disabled?.(row)"
-                        (click)="action.action(row)">
+                        (click)="$event.stopPropagation(); action.action(row)">
                         <span> {{ action.label }}</span>
                       </button>
                     }

--- a/sp1-custom-table/src/styles.scss
+++ b/sp1-custom-table/src/styles.scss
@@ -1,7 +1,7 @@
 /* You can add global styles to this file, and also import other style files */
 
-// @import '@angular/material/prebuilt-themes/cyan-orange.css';
-@import '@angular/material/prebuilt-themes/azure-blue.css';
+@import '@angular/material/prebuilt-themes/cyan-orange.css';
+// @import '@angular/material/prebuilt-themes/azure-blue.css';
 
 :root {
   --spinner-background: rgba(255, 255, 255, 0.6);
@@ -35,4 +35,8 @@ body {
   position: absolute;
   width: 100%;
   height: 100%;
+}
+
+.mat-mdc-menu-item:focus {
+  outline: 1px solid currentColor !important;
 }

--- a/sp1-custom-table/src/styles.scss
+++ b/sp1-custom-table/src/styles.scss
@@ -38,5 +38,5 @@ body {
 }
 
 .mat-mdc-menu-item:focus {
-  outline: 1px solid currentColor !important;
+  outline: 2px solid currentColor !important;
 }


### PR DESCRIPTION
- Menus do not close when menu action is selected keeping focus on menu until user has decided to complete all actions
- Extra focus outline for menu items (2px - WCAG 2.4.13 AAA)