### PR TITLE
Remove onChange

### DIFF
--- a/sp1-custom-table/src/app/shared/components/table/models/column.model.ts
+++ b/sp1-custom-table/src/app/shared/components/table/models/column.model.ts
@@ -132,13 +132,6 @@ interface CheckboxColumn<T> extends BaseColumn<T> {
    * @returns Whether the checkbox is checked.
    */
   checked: (row: T) => boolean;
-  /**
-   * Function to handle checkbox value change.
-   * @param checked - Whether the checkbox is checked.
-   * @param row - The row data.
-   * @optional
-   */
-  onChange?: (checked: boolean, row: T) => void;
 }
 
 interface SlideToggleColumn<T> extends BaseColumn<T> {
@@ -152,11 +145,4 @@ interface SlideToggleColumn<T> extends BaseColumn<T> {
    * @returns Whether the slide toggle is checked.
    */
   checked: (row: T) => boolean;
-  /**
-   * Function to handle slide toggle value change.
-   * @param checked - Whether the slide toggle is checked.
-   * @param row - The row data.
-   * @optional
-   */
-  onChange?: (checked: boolean, row: T) => void;
 }


### PR DESCRIPTION
onChange callback functions removed from CheckboxColumn and SlideToggleColumn. Table does not support inline row editing so callbacks are not needed to handle change emissions when elements are disabled.