### PR TITLE
111 update how spinner interacts with table

### DIFF
--- a/sp1-custom-table/src/app/shared/components/table/table.component.html
+++ b/sp1-custom-table/src/app/shared/components/table/table.component.html
@@ -111,7 +111,7 @@
       <ng-content />
     
       <div class="table-container" [class.is-loading]="loading">
-        @if (loadingTail) {
+        @if (loading) {
           <mat-progress-bar class="progress-bar"
             mode="indeterminate"
             [@fadeInOut]

--- a/sp1-custom-table/src/app/shared/components/table/table.component.html
+++ b/sp1-custom-table/src/app/shared/components/table/table.component.html
@@ -114,7 +114,8 @@
         @if (loadingTail) {
           <mat-progress-bar class="progress-bar"
             mode="indeterminate"
-            [@fadeInOut]>
+            [@fadeInOut]
+            [class.pulsing]="loading">
           </mat-progress-bar>
         }
 

--- a/sp1-custom-table/src/app/shared/components/table/table.component.html
+++ b/sp1-custom-table/src/app/shared/components/table/table.component.html
@@ -112,11 +112,12 @@
     
       <div class="table-container" [class.is-loading]="loading">
         @if (loadingTail) {
-          <mat-progress-bar
+          <mat-progress-bar class="progress-bar"
             mode="indeterminate"
             [@fadeInOut]>
           </mat-progress-bar>
         }
+
         <table mat-table
           [dataSource]="tableData"
           matSort

--- a/sp1-custom-table/src/app/shared/components/table/table.component.scss
+++ b/sp1-custom-table/src/app/shared/components/table/table.component.scss
@@ -32,12 +32,20 @@
 .table-container {
   margin: 0 auto;
   overflow: auto;
+  position: relative;
 
   &.is-loading {
     :not(:first-child) {
       opacity: 55%;
     }
   }
+}
+
+.progress-bar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 110;
 }
 
 table {

--- a/sp1-custom-table/src/app/shared/components/table/table.component.scss
+++ b/sp1-custom-table/src/app/shared/components/table/table.component.scss
@@ -48,6 +48,29 @@
   z-index: 110;
 }
 
+/* Define the pulsing animation */
+@keyframes pulse {
+  0% {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  50% {
+    opacity: 0.5;
+    transform: scale(1.5);
+  }
+
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+/* Apply the animation to elements with the class "pulse" */
+.pulsing {
+  animation: pulse 3s ease-in-out infinite;
+}
+
 table {
   width: 100%;
 

--- a/sp1-custom-table/src/app/shared/components/table/table.component.ts
+++ b/sp1-custom-table/src/app/shared/components/table/table.component.ts
@@ -87,17 +87,13 @@ export class TableComponent<T> implements OnChanges, OnInit, OnDestroy {
     if (value) {
       // Store the current focused element, will check later if it is the search bar for restoration.
       this._focusedElement = document.activeElement;
-      this.loadingTail = true;
       this.searchControl.disable({ emitEvent: false });
     } else {
+      // A little scuffed since the placeholder is not showing upon refocus.
+      if (this._focusedElement instanceof HTMLInputElement) {
+        this._focusedElement.focus();
+      }
       this.searchControl.enable({ emitEvent: false });
-      setTimeout(() => {
-        this.loadingTail = false;
-        // A little scuffed since the placeholder is not showing upon refocus.
-        if (this._focusedElement instanceof HTMLInputElement) {
-          this._focusedElement.focus();
-        }
-      }, 500);
     }
   }
   private _loading!: boolean;
@@ -121,9 +117,6 @@ export class TableComponent<T> implements OnChanges, OnInit, OnDestroy {
 
   // Tooltip vars.
   protected multiRowActionMenuTooltip = 'Show more actions';
-
-  // Magic animation var.
-  protected loadingTail!: boolean;
 
   // Search bar filter vars.
   static nextId = 0;


### PR DESCRIPTION
- Add animation for pulsing the progress bar. Hopefully it gives an extra feeling of "working on it"
- remove the boolean loadingTail since the spinner is gone now
- Locked the progress bar atop the table to prevent the table from doing a slight shift