### PR TITLE
123 - Add hover styling

### DIFF
--- a/sp1-custom-table/src/app/app.component.ts
+++ b/sp1-custom-table/src/app/app.component.ts
@@ -123,9 +123,11 @@ export class AppComponent implements OnInit {
       showHideColumns: true,
       reorderColumns: true,
     },
-    showRowNumbers: true,
-    multiRowSelection: true,
-    rowClass: (row: MockModel) => (row.name === 'Calcium' ? ['gold', 'bold'] : ''),
+    rowsConfig: {
+      showRowNumbers: true,
+      multiRowSelection: true,
+      rowClass: (row: MockModel) => (row.name === 'Calcium' ? ['gold', 'bold'] : ''),
+    },
     sortOptions: {
       sortFunc(item, property): string | number {
         if (property === 'discoveryLocation') {

--- a/sp1-custom-table/src/app/app.component.ts
+++ b/sp1-custom-table/src/app/app.component.ts
@@ -126,6 +126,7 @@ export class AppComponent implements OnInit {
     rowsConfig: {
       showRowNumbers: true,
       multiRowSelection: true,
+      hover: true,
       rowClass: (row: MockModel) => (row.name === 'Calcium' ? ['gold', 'bold'] : ''),
     },
     sortOptions: {

--- a/sp1-custom-table/src/app/shared/components/table/models/rows.model.ts
+++ b/sp1-custom-table/src/app/shared/components/table/models/rows.model.ts
@@ -1,0 +1,29 @@
+export interface RowsConfig<T> {
+
+  /**
+   * Determines whether to display row numbers.
+   *
+   * @default false
+   */
+  showRowNumbers?: boolean;
+
+  /**
+   * Enables multi-row selection mode.
+   *
+   * @default false
+   */
+  multiRowSelection?: boolean;
+
+  /**
+   * Function to determine the CSS class(es) applied to a row.
+   *
+   * @param row - The row data.
+   * @returns A string or an array of CSS class names.
+   *
+   * @example
+   * ```typescript
+   * rowClass: (row) => row.active ? 'highlight' : 'dimmed'
+   * ```
+   */
+  rowClass?: (row: T) => string | string[];
+}

--- a/sp1-custom-table/src/app/shared/components/table/models/rows.model.ts
+++ b/sp1-custom-table/src/app/shared/components/table/models/rows.model.ts
@@ -1,5 +1,4 @@
 export interface RowsConfig<T> {
-
   /**
    * Determines whether to display row numbers.
    *
@@ -13,6 +12,13 @@ export interface RowsConfig<T> {
    * @default false
    */
   multiRowSelection?: boolean;
+
+  /**
+   * Determines whether rows should have a hover effect.
+   *
+   * @default false
+   */
+  hover?: boolean;
 
   /**
    * Function to determine the CSS class(es) applied to a row.

--- a/sp1-custom-table/src/app/shared/components/table/models/table.model.ts
+++ b/sp1-custom-table/src/app/shared/components/table/models/table.model.ts
@@ -3,6 +3,7 @@ import { ColumnsConfig } from './column.model';
 import { RowActionsConfig, TableAction, SelectedRowAction } from './actions.model';
 import { SortConfig } from './sort.model';
 import { AutoRefreshConfig } from './auto-refresh.model';
+import { RowsConfig } from './rows.model';
 
 /**
  * Configuration options for a table component.
@@ -26,36 +27,14 @@ export interface TableConfig<T> {
   columnsConfig: ColumnsConfig;
 
   /**
-   * Determines whether to display row numbers.
-   *
-   * @default false
+   * Configuration for table columns.
    */
-  showRowNumbers?: boolean;
-
-  /**
-   * Enables multi-row selection mode.
-   *
-   * @default false
-   */
-  multiRowSelection?: boolean;
+  rowsConfig?: RowsConfig<T>;
 
   /**
    * Configuration for automatically refreshing table data.
    */
   autoRefresh?: AutoRefreshConfig;
-
-  /**
-   * Function to determine the CSS class(es) applied to a row.
-   *
-   * @param row - The row data.
-   * @returns A string or an array of CSS class names.
-   *
-   * @example
-   * ```typescript
-   * rowClass: (row) => row.active ? 'highlight' : 'dimmed'
-   * ```
-   */
-  rowClass?: (row: T) => string | string[];
 
   /**
    * Configuration for table sorting options.

--- a/sp1-custom-table/src/app/shared/components/table/models/table.model.ts
+++ b/sp1-custom-table/src/app/shared/components/table/models/table.model.ts
@@ -27,7 +27,7 @@ export interface TableConfig<T> {
   columnsConfig: ColumnsConfig;
 
   /**
-   * Configuration for table columns.
+   * Configuration for table rows.
    */
   rowsConfig?: RowsConfig<T>;
 

--- a/sp1-custom-table/src/app/shared/components/table/table.component.html
+++ b/sp1-custom-table/src/app/shared/components/table/table.component.html
@@ -215,7 +215,8 @@
           <!-- Data rows -->
           <tr mat-row *matRowDef="let row; columns: displayColumns"
             [class.showActions]="tableConfig.rowActions"
-            [ngClass]="tableConfig.rowsConfig?.rowClass?.(row) ?? ''"></tr>
+            [ngClass]="tableConfig.rowsConfig?.rowClass?.(row) ?? ''"
+            [class.hover]="tableConfig.rowsConfig?.hover"></tr>
           <tr *matNoDataRow>No data to display</tr>
         </table>
       </div>

--- a/sp1-custom-table/src/app/shared/components/table/table.component.html
+++ b/sp1-custom-table/src/app/shared/components/table/table.component.html
@@ -128,7 +128,7 @@
           (matSortChange)="onSortChange($event)">
     
           <!-- Column for multiple row checkbox selection. -->
-          @if (tableConfig.multiRowSelection) {
+          @if (tableConfig.rowsConfig?.multiRowSelection) {
             <ng-container matColumnDef="select">
               <th mat-header-cell *matHeaderCellDef>
                 <mat-checkbox
@@ -147,7 +147,7 @@
           }
     
           <!-- Column for numbered rows. -->
-          @if (tableConfig.showRowNumbers) {
+          @if (tableConfig.rowsConfig?.showRowNumbers) {
             <ng-container matColumnDef="#">
               <th mat-header-cell *matHeaderCellDef> # </th>
               <td mat-cell *matCellDef="let row; let i = index"> {{ getRowNumber(i) }} </td>
@@ -215,7 +215,7 @@
           <!-- Data rows -->
           <tr mat-row *matRowDef="let row; columns: displayColumns"
             [class.showActions]="tableConfig.rowActions"
-            [ngClass]="tableConfig.rowClass?.(row) ?? ''"></tr>
+            [ngClass]="tableConfig.rowsConfig?.rowClass?.(row) ?? ''"></tr>
           <tr *matNoDataRow>No data to display</tr>
         </table>
       </div>

--- a/sp1-custom-table/src/app/shared/components/table/table.component.scss
+++ b/sp1-custom-table/src/app/shared/components/table/table.component.scss
@@ -98,7 +98,7 @@ table {
   }
 
   &.hover:hover {
-    background-color: var(--twt-row-hover);
+    background-color: var(--twt-row-hover-background);
   }
 }
 

--- a/sp1-custom-table/src/app/shared/components/table/table.component.scss
+++ b/sp1-custom-table/src/app/shared/components/table/table.component.scss
@@ -96,6 +96,10 @@ table {
   &.showActions {
     height: 52px;
   }
+
+  &.hover:hover {
+    background-color: var(--twt-row-hover);
+  }
 }
 
 .mat-column-actions,

--- a/sp1-custom-table/src/app/shared/components/table/table.component.ts
+++ b/sp1-custom-table/src/app/shared/components/table/table.component.ts
@@ -316,12 +316,12 @@ export class TableComponent<T> implements OnChanges, OnInit, OnDestroy {
     this.displayColumns = columns.filter(col => col.visible ?? true).map(col => col.field);
 
     // Include the row number column.
-    if (this.tableConfig.showRowNumbers) {
+    if (this.tableConfig.rowsConfig?.showRowNumbers) {
       this.displayColumns.unshift('#');
     }
 
     // Include the multi-row select column.
-    if (this.tableConfig.multiRowSelection) {
+    if (this.tableConfig.rowsConfig?.multiRowSelection) {
       this.displayColumns.unshift('select');
     }
 

--- a/sp1-custom-table/src/styles.scss
+++ b/sp1-custom-table/src/styles.scss
@@ -8,6 +8,7 @@
   --paginator-height: 56px;
   --paginator-mat-form-field-height: 41px;
   --paginator-range-actions-height: 40px;
+  --twt-row-hover: #e8e8e8;
 }
 
 html,

--- a/sp1-custom-table/src/styles.scss
+++ b/sp1-custom-table/src/styles.scss
@@ -8,7 +8,7 @@
   --paginator-height: 56px;
   --paginator-mat-form-field-height: 41px;
   --paginator-range-actions-height: 40px;
-  --twt-row-hover: #e8e8e8;
+  --twt-row-hover-background: #e8e8e8;
 }
 
 html,


### PR DESCRIPTION
- New optional property, hover: boolean, on interface RowsConfig. Allows for hover styling to take place on a row
- Color endpoint exposed via css variable `twt-row-hover-background`