### PR TITLE
#124 - Add zebra row option

### DIFF
--- a/sp1-custom-table/src/app/app.component.ts
+++ b/sp1-custom-table/src/app/app.component.ts
@@ -127,6 +127,7 @@ export class AppComponent implements OnInit {
       showRowNumbers: true,
       multiRowSelection: true,
       hover: true,
+      zebraRows: true,
       rowClass: (row: MockModel) => (row.name === 'Calcium' ? ['gold', 'bold'] : ''),
     },
     sortOptions: {

--- a/sp1-custom-table/src/app/shared/components/table/models/rows.model.ts
+++ b/sp1-custom-table/src/app/shared/components/table/models/rows.model.ts
@@ -21,6 +21,13 @@ export interface RowsConfig<T> {
   hover?: boolean;
 
   /**
+   * Determines whether rows should have alternating row colors.
+   *
+   * @default false
+   */
+  zebraRows?: boolean;
+
+  /**
    * Function to determine the CSS class(es) applied to a row.
    *
    * @param row - The row data.

--- a/sp1-custom-table/src/app/shared/components/table/table.component.html
+++ b/sp1-custom-table/src/app/shared/components/table/table.component.html
@@ -216,7 +216,9 @@
           <tr mat-row *matRowDef="let row; columns: displayColumns"
             [class.showActions]="tableConfig.rowActions"
             [ngClass]="tableConfig.rowsConfig?.rowClass?.(row) ?? ''"
-            [class.hover]="tableConfig.rowsConfig?.hover"></tr>
+            [class.hover]="tableConfig.rowsConfig?.hover"
+            [class.zebra-rows]="tableConfig.rowsConfig?.zebraRows">
+          </tr>
           <tr *matNoDataRow>No data to display</tr>
         </table>
       </div>

--- a/sp1-custom-table/src/app/shared/components/table/table.component.scss
+++ b/sp1-custom-table/src/app/shared/components/table/table.component.scss
@@ -105,8 +105,12 @@ table {
     background-color: var(--twt-row-zebra-even-background);
   }
 
-  &.hover:hover {
-    background-color: var(--twt-row-hover-background);
+  &.hover:hover:nth-child(odd) {
+    background-color: var(--twt-row-hover-odd-background);
+  }
+
+  &.hover:hover:nth-child(even) {
+    background-color: var(--twt-row-hover-even-background);
   }
 }
 

--- a/sp1-custom-table/src/app/shared/components/table/table.component.scss
+++ b/sp1-custom-table/src/app/shared/components/table/table.component.scss
@@ -97,6 +97,14 @@ table {
     height: 52px;
   }
 
+  &.zebra-rows:nth-child(odd) {
+    background-color: var(--twt-row-zebra-odd-background);
+  }
+
+  &.zebra-rows:nth-child(even) {
+    background-color: var(--twt-row-zebra-even-background);
+  }
+
   &.hover:hover {
     background-color: var(--twt-row-hover-background);
   }

--- a/sp1-custom-table/src/styles.scss
+++ b/sp1-custom-table/src/styles.scss
@@ -8,8 +8,9 @@
   --paginator-height: 56px;
   --paginator-mat-form-field-height: 41px;
   --paginator-range-actions-height: 40px;
-  --twt-row-hover-background: #e8e8e8;
-  --twt-row-zebra-odd-background: #f5f5f5;
+  --twt-row-hover-odd-background: #d0d0d0;
+  --twt-row-hover-even-background: #dddddd;
+  --twt-row-zebra-odd-background: #eeeeee;
   --twt-row-zebra-even-background: var(--mat-app-background-color);
 }
 

--- a/sp1-custom-table/src/styles.scss
+++ b/sp1-custom-table/src/styles.scss
@@ -9,6 +9,8 @@
   --paginator-mat-form-field-height: 41px;
   --paginator-range-actions-height: 40px;
   --twt-row-hover-background: #e8e8e8;
+  --twt-row-zebra-odd-background: #f5f5f5;
+  --twt-row-zebra-even-background: var(--mat-app-background-color);
 }
 
 html,


### PR DESCRIPTION
- Added property zebraRows, boolean, for alternating row color styles to RowsConfig
- Exposed endpoint for odd and even colors via `twt-row-zebra-odd-background` and `twt-row-zebra-even-background` root css variables
- Updated hover styling to apply odd and even color